### PR TITLE
Logging and Site directory migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .idea
 *.log
 tmp/*
+tests/*
 **/__pycache__/**
 readme.org

--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+CLI_DIR = Path.home() / 'frappe'

--- a/frappe_manager/docker_wrapper/DockerCompose.py
+++ b/frappe_manager/docker_wrapper/DockerCompose.py
@@ -1,12 +1,9 @@
 from subprocess import Popen, run, TimeoutExpired, CalledProcessError
 from pathlib import Path
-import subprocess
 from typing import Union, Literal
-from rich import print
 
 import shlex
 from frappe_manager.docker_wrapper.utils import (
-    stream_stdout_and_stderr,
     parameters_to_options,
     run_command_with_exit_code,
 )

--- a/frappe_manager/logger/__init__.py
+++ b/frappe_manager/logger/__init__.py
@@ -1,0 +1,1 @@
+from . import log

--- a/frappe_manager/logger/log.py
+++ b/frappe_manager/logger/log.py
@@ -1,0 +1,46 @@
+import logging
+import logging.handlers
+import os
+from frappe_manager import CLI_DIR
+import shutil
+import gzip
+from typing import Dict, Optional, Union
+
+
+def namer(name):
+    return name + ".gz"
+
+def rotator(source, dest):
+    with open(source, 'rb') as f_in:
+        with gzip.open(dest, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    os.remove(source)
+
+loggers: Dict[str, logging.Logger] = {}
+log_directory = CLI_DIR / 'logs'
+
+def get_logger(log_dir=log_directory, log_file_name='fm') -> logging.Logger:
+    """ Creates a Log File and returns Logger object """
+    # Build Log File Full Path
+    logPath = log_dir / f"{log_file_name}.log"
+
+    # if the directory doesn't exits then create it
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create logger object and set the format for logging and other attributes
+    if loggers.get(log_file_name):
+        logger: Optional[logging.Logger] = loggers.get(log_file_name)
+    else:
+        logger: Optional[logging.Logger] = logging.getLogger(log_file_name)
+        logger.setLevel(logging.DEBUG)
+
+        # configured to roatate after 10 mb
+        handler = logging.handlers.RotatingFileHandler(logPath,'a+',maxBytes=10485760, backupCount=3)
+        handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
+        handler.rotator = rotator
+        logger.addHandler(handler)
+
+        # save logger to dict loggers
+        loggers[log_file_name] = logger
+
+    return logger

--- a/frappe_manager/site_manager/manager.py
+++ b/frappe_manager/site_manager/manager.py
@@ -370,7 +370,8 @@ class SiteManager:
                 db_pass= site_config['db_password']
 
         frappe_password = self.site.composefile.get_envs('frappe')['ADMIN_PASS']
-        site_info_table = Table(box=box.ASCII2,show_lines=True,show_header=False)
+        root_db_password = self.site.composefile.get_envs('mariadb')['MYSQL_ROOT_PASSWORD']
+        site_info_table = Table(box=box.ASCII2,show_lines=True,show_header=False,highlight=True)
         data = {
             "Site Url":f"http://{self.site.name}",
             "Site Root":f"{self.site.path.absolute()}",
@@ -378,28 +379,36 @@ class SiteManager:
             "Adminer Url":f"http://{self.site.name}/adminer",
             "Frappe Username" : "administrator",
             "Frappe Password" : frappe_password,
-            "DB Host" : f"mariadb",
+            "Root DB User" : 'root',
+            "Root DB Password" : root_db_password,
+            "DB Host" : "mariadb",
             "DB Name" : db_user,
             "DB User" : db_user,
             "DB Password" : db_pass,
+
             }
         site_info_table.add_column()
         site_info_table.add_column()
         for key in data.keys():
             site_info_table.add_row(key,data[key])
-        richprint.stdout.print(site_info_table)
+
         # bench apps list
         richprint.stdout.print('')
-        bench_apps_list_table=Table(title="Bench Apps",box=box.ASCII2,show_lines=True)
+        # bench_apps_list_table=Table(title="Bench Apps",box=box.ASCII2,show_lines=True)
+        bench_apps_list_table=Table(box=box.ASCII2,show_lines=True,expand=True,show_edge=False,pad_edge=False)
         bench_apps_list_table.add_column("App")
         bench_apps_list_table.add_column("Version")
+
+
         apps_json_file = self.site.path / 'workspace' / 'frappe-bench' / 'sites' / 'apps.json'
         if apps_json_file.exists():
             with open(apps_json_file,'r') as f:
                 apps_json = json.load(f)
                 for app in apps_json.keys():
                     bench_apps_list_table.add_row(app,apps_json[app]['version'])
-                richprint.stdout.print(bench_apps_list_table)
+
+            site_info_table.add_row('Bench Apps',bench_apps_list_table)
+        richprint.stdout.print(site_info_table)
 
     def migrate_site(self):
         """

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -44,7 +44,7 @@ class Site:
         sitename = self.name
         match = re.search(r'^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?.localhost$',sitename)
         if not match:
-            richprint.exit("The site name on localhost must follow a single-level subdomain Fully Qualified Domain Name (FQDN) format, such as 'suddomain.localhost'.")
+            richprint.exit("The site name must follow a single-level subdomain Fully Qualified Domain Name (FQDN) format of localhost, such as 'suddomain.localhost'.")
 
     def get_frappe_container_hex(self) -> None | str:
         """
@@ -56,7 +56,7 @@ class Site:
         container_name = self.composefile.get_container_names()
         return container_name['frappe'].encode().hex()
 
-    def migrate_site(self) :
+    def migrate_site_compose(self) :
         """
         The `migrate_site` function checks the environment version and migrates it if necessary.
         :return: a boolean value,`True` if the site migrated else `False`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "frappe-manager"
-version = "0.8.3"
+version = "0.8.4"
 license = "MIT"
 repository = "https://github.com/rtcamp/frappe-manager"
 description = "A CLI tool based on Docker Compose to easily manage Frappe based projects. As of now, only suitable for development in local machines running on Mac and Linux based OS."
@@ -13,7 +13,7 @@ readme = "README.md"
 "Bug Tracker" = "https://github.com/rtcamp/frappe-manager/issues"
 
 [tool.poetry.scripts]
-fm = "frappe_manager.main:app"
+fm = "frappe_manager.main:cli_entrypoint"
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
This PR:

1.  **Introduces change in cli directory structure i.e structure of `/home/<user>/frappe` directory.** (#59) This new directories are introduced in cli directory to compensate different changes.
    -   *Logs* are stored in `/home/<user>/frappe/logs`.
    -   *Sites* are stored in `/home/<user>/frappe/sites`, previously sites were stored in `/home/<user>/frappe`.

2.  **Introduces logging system** as a module.
    -   logs:
        -   command invoked by user when running fm.
        -   executed docker commands, command output and return code.
        -   exception happend during runtime.
    -   rotates logs when the log size hits 10 MB, creates files like `fm.log.1` when rotate limit is reached.
    -   the logs are stored in file `fm.log`.

3.  Improves caret not lost after unexpected exit of the cli. Introduce exit cleanup function.
4.  Optimize checking of site existence.
5. #64