### PR TITLE
`fm logs <sitename>` should show frappe dev server logs and other fixes

### DIFF
--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -1,3 +1,26 @@
 from pathlib import Path
+from enum import Enum
 
-CLI_DIR = Path.home() / 'frappe'
+# TODO configure this using config
+#sites_dir = Path().home() / __name__.split(".")[0]
+CLI_DIR = Path.home() / 'fm'
+
+default_extension = [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "ms-python.python",
+    "ms-python.black-formatter",
+    "ms-python.flake8",
+    "visualstudioexptteam.vscodeintellicode",
+    "VisualStudioExptTeam.intellicode-api-usage-examples"
+]
+
+class SiteServicesEnum(str, Enum):
+    frappe= "frappe"
+    nginx = "nginx"
+    mailhog = "mailhog"
+    adminer = "adminer"
+    mariadb = "mariadb"
+    redis_queue = "redis-queue"
+    redis_cache = "redis-cache"
+    redis_socketio = "redis-socketio"

--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 # TODO configure this using config
 #sites_dir = Path().home() / __name__.split(".")[0]
-CLI_DIR = Path.home() / 'fm'
+CLI_DIR = Path.home() / 'frappe'
 
 default_extension = [
     "dbaeumer.vscode-eslint",

--- a/frappe_manager/main.py
+++ b/frappe_manager/main.py
@@ -106,18 +106,6 @@ def app_callback(
     if verbose:
         sites.set_verbose()
 
-
-default_extension = [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "ms-python.python",
-    "ms-python.black-formatter",
-    "ms-python.flake8",
-    "visualstudioexptteam.vscodeintellicode",
-    "VisualStudioExptTeam.intellicode-api-usage-examples"
-]
-
-
 def check_frappe_app_exists(appname: str, branchname: str | None = None):
     # check appname
     try:
@@ -309,10 +297,10 @@ def code(
 @app.command(no_args_is_help=True)
 def logs(
     sitename: Annotated[str, typer.Argument(help="Name of the site.")],
-    service: Annotated[str, typer.Option(help="Specify Service")] = "frappe",
+    service: Annotated[Optional[SiteServicesEnum], typer.Option(help="Specify service name to show container logs.")] = None,
     follow: Annotated[bool, typer.Option(help="Follow logs.")] = False,
 ):
-    """Show logs for the given site. """
+    """Show frappe dev server logs or container logs for a given site. """
     sites.init(sitename)
     sites.logs(service,follow)
 
@@ -321,7 +309,7 @@ def logs(
 def shell(
     sitename: Annotated[str, typer.Argument(help="Name of the site.")],
     user: Annotated[str, typer.Option(help="Connect as this user.")] = None,
-    service: Annotated[str, typer.Option(help="Specify Service")] = "frappe",
+    service: Annotated[SiteServicesEnum, typer.Option(help="Specify Service")] = 'frappe',
 ):
     """Open shell for the give site. """
     sites.init(sitename)

--- a/frappe_manager/main.py
+++ b/frappe_manager/main.py
@@ -5,16 +5,13 @@ import requests
 import sys
 import shutil
 import atexit
-from typing import Annotated, List, Optional, Set
+from typing import Annotated, List, Literal, Optional, Set
 from frappe_manager.site_manager.manager import SiteManager
 from frappe_manager.site_manager.Richprint import richprint
-from frappe_manager import CLI_DIR
+from frappe_manager import CLI_DIR, default_extension, SiteServicesEnum
 from frappe_manager.logger import log
 
 app = typer.Typer(no_args_is_help=True,rich_markup_mode='rich')
-
-# TODO configure this using config
-#sites_dir = Path().home() / __name__.split(".")[0]
 
 def exit_cleanup():
     """
@@ -62,19 +59,20 @@ def app_callback(
     """
     richprint.start(f"Working")
 
+    sitesdir = CLI_DIR / 'sites'
     # Checks for cli directory
     if not CLI_DIR.exists():
         # creating the sites dir
         # TODO check if it's writeable and readable -> by writing a file to it and catching exception
         CLI_DIR.mkdir(parents=True, exist_ok=True)
+        sitesdir.mkdir(parents=True, exist_ok=True)
         richprint.print(f"fm directory doesn't exists! Created at -> {str(CLI_DIR)}")
     else:
         if not CLI_DIR.is_dir():
             richprint.exit("Sites directory is not a directory! Aborting!")
 
-    # migration for directory change from CLI_DIR to CLI_DIR/sites
+    # Migration for directory change from CLI_DIR to CLI_DIR/sites
     # TODO remove when not required, introduced in 0.8.4
-    sitesdir = CLI_DIR / 'sites'
     if not sitesdir.exists():
         richprint.change_head("Site directory migration")
         move_directory_list = []

--- a/frappe_manager/main.py
+++ b/frappe_manager/main.py
@@ -298,7 +298,7 @@ def code(
 def logs(
     sitename: Annotated[str, typer.Argument(help="Name of the site.")],
     service: Annotated[Optional[SiteServicesEnum], typer.Option(help="Specify service name to show container logs.")] = None,
-    follow: Annotated[bool, typer.Option(help="Follow logs.")] = False,
+    follow: Annotated[bool, typer.Option('--follow','-f',help="Follow logs.")] = False,
 ):
     """Show frappe dev server logs or container logs for a given site. """
     sites.init(sitename)

--- a/frappe_manager/site_manager/manager.py
+++ b/frappe_manager/site_manager/manager.py
@@ -299,8 +299,13 @@ class SiteManager:
         are generated. If "follow" is set to False, only the existing logs will be displayed
         """
         richprint.change_head(f"Showing logs")
+
         if self.site.running():
-            self.site.logs(service,follow)
+
+            if service:
+                self.site.logs(service,follow)
+            else:
+                self.site.bench_dev_server_logs(follow)
         else:
             richprint.error(
                 f"Site {self.site.name} not running!"

--- a/frappe_manager/site_manager/manager.py
+++ b/frappe_manager/site_manager/manager.py
@@ -45,12 +45,12 @@ class SiteManager:
             if self.typer_context.invoked_subcommand in site_directory_exits_check_for_commands:
                 if sitepath.exists():
                     richprint.exit(
-                        f"Site {sitename} already exists! Aborting! -> [bold cyan] {sitepath}[/bold cyan]"
+                        f"The site '{sitename}' already exists at {sitepath}. Aborting operation."
                     )
             else:
                 if not sitepath.exists():
                     richprint.exit(
-                        f"Site {sitename} doesn't exists! Aborting! -> [bold cyan] {sitepath}[/bold cyan]"
+                        f"The site '{sitename}' does not exist. Aborting operation."
                     )
 
             self.site: Site = Site(sitepath, sitename, verbose= self.verbose)

--- a/frappe_manager/site_manager/manager.py
+++ b/frappe_manager/site_manager/manager.py
@@ -8,6 +8,7 @@ import typer
 import shutil
 
 from frappe_manager.site_manager.site import Site
+from frappe_manager.site_manager.utils import check_ports
 from frappe_manager.site_manager.Richprint import richprint
 
 from rich.columns import Columns
@@ -312,24 +313,11 @@ class SiteManager:
         """
         richprint.change_head("Checking Ports")
         to_check = [9000,80,443]
-        already_binded = []
-
-        for port in to_check:
-        # check port using lsof
-            cmd = f"lsof -iTCP:{port} -sTCP:LISTEN -P -n"
-            try:
-                output = subprocess.run(cmd,check=True,shell=True,capture_output=True)
-                if output.returncode == 0:
-                    already_binded.append(port)
-            except subprocess.CalledProcessError as e:
-                pass
-
+        already_binded = check_ports(to_check)
         if already_binded:
-            # TODO handle if ports are open using docker
-            # show warning and exit
-            #richprint.error(f"{' '.join([str(x) for x in already_binded])} ports { 'are' if len(already_binded) > 1 else 'is' } already in use. Please free these ports.")
-            richprint.exit(f" Whoa there! Looks like the {' '.join([ str(x) for x in already_binded ])} { 'ports are' if len(already_binded) > 1 else 'port is' } having a party already! Can you do us a solid and free up those ports? They're in high demand and ready to mingle!")
+            richprint.exit(f"Whoa there! Looks like the {' '.join([ str(x) for x in already_binded ])} { 'ports are' if len(already_binded) > 1 else 'port is' } having a party already! Can you do us a solid and free up those ports?")
         richprint.print("Ports Check : Passed")
+
 
     def shell(self,container:str, user:str | None):
         """

--- a/frappe_manager/site_manager/utils.py
+++ b/frappe_manager/site_manager/utils.py
@@ -47,3 +47,27 @@ def check_ports(ports):
                     already_binded.append(port)
 
         return already_binded
+
+def log_file(file, refresh_time:float = 0.1, follow:bool =False):
+    '''generator function that yields new lines in a file
+    '''
+    # while True:
+    #     line = file.readline()        # sleep if file hasn't been updated
+    #     yield line
+    #     if not line:
+    #         break
+    # seek the end of the file
+    # file.seek(0, os.SEEK_END)
+    file.seek(0)
+
+    # start infinite loop
+    while True:
+        # read last line of file
+        line = file.readline()        # sleep if file hasn't been updated
+        if not line:
+            if not follow:
+                break
+            time.sleep(refresh_time)
+            continue
+        line = line.strip('\n')
+        yield line

--- a/frappe_manager/site_manager/utils.py
+++ b/frappe_manager/site_manager/utils.py
@@ -1,0 +1,49 @@
+import time
+import platform
+import subprocess
+import os
+
+def is_port_in_use(port):
+    """
+    Check if port is in use or not.
+
+    :param port: The port which will be checked if it's in use or not.
+    :return: Bool In use then True and False when not in use.
+    """
+    import psutil
+    for conn in psutil.net_connections():
+        if conn.laddr.port == port and conn.status == 'LISTEN':
+            return True
+    return False
+
+def check_ports(ports):
+        """
+        This function checks if the ports is in use.
+        :param ports: list of ports to be checked
+        returns: list of binded port(can be empty)
+        """
+
+        # TODO handle if ports are open using docker
+
+        current_system = platform.system()
+
+        already_binded = []
+
+        for port in ports:
+            if current_system == 'Darwin':
+
+                # Mac Os
+                # check port using lsof command
+                cmd = f"lsof -iTCP:{port} -sTCP:LISTEN -P -n"
+                try:
+                    output = subprocess.run(cmd,check=True,shell=True,capture_output=True)
+                    if output.returncode == 0:
+                        already_binded.append(port)
+                except subprocess.CalledProcessError as e:
+                    pass
+            else:
+                # Linux or any other machines
+                if is_port_in_use(port):
+                    already_binded.append(port)
+
+        return already_binded

--- a/poetry.lock
+++ b/poetry.lock
@@ -147,6 +147,23 @@ files = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.2"
+description = "A very fast and expressive template engine."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -171,6 +188,65 @@ rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
+name = "markupsafe"
+version = "2.1.3"
+description = "Safely add untrusted strings to HTML/XML markup."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-win32.whl", hash = "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431"},
+    {file = "MarkupSafe-2.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
+    {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-win32.whl", hash = "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0"},
+    {file = "MarkupSafe-2.1.3-cp37-cp37m-win_amd64.whl", hash = "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-win32.whl", hash = "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5"},
+    {file = "MarkupSafe-2.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-win32.whl", hash = "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"},
+    {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
+    {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
@@ -180,6 +256,34 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+
+[[package]]
+name = "psutil"
+version = "5.9.6"
+description = "Cross-platform lib for process and system monitoring in Python."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+files = [
+    {file = "psutil-5.9.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fb8a697f11b0f5994550555fcfe3e69799e5b060c8ecf9e2f75c69302cc35c0d"},
+    {file = "psutil-5.9.6-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:91ecd2d9c00db9817a4b4192107cf6954addb5d9d67a969a4f436dbc9200f88c"},
+    {file = "psutil-5.9.6-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:10e8c17b4f898d64b121149afb136c53ea8b68c7531155147867b7b1ac9e7e28"},
+    {file = "psutil-5.9.6-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:18cd22c5db486f33998f37e2bb054cc62fd06646995285e02a51b1e08da97017"},
+    {file = "psutil-5.9.6-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:ca2780f5e038379e520281e4c032dddd086906ddff9ef0d1b9dcf00710e5071c"},
+    {file = "psutil-5.9.6-cp27-none-win32.whl", hash = "sha256:70cb3beb98bc3fd5ac9ac617a327af7e7f826373ee64c80efd4eb2856e5051e9"},
+    {file = "psutil-5.9.6-cp27-none-win_amd64.whl", hash = "sha256:51dc3d54607c73148f63732c727856f5febec1c7c336f8f41fcbd6315cce76ac"},
+    {file = "psutil-5.9.6-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c69596f9fc2f8acd574a12d5f8b7b1ba3765a641ea5d60fb4736bf3c08a8214a"},
+    {file = "psutil-5.9.6-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92e0cc43c524834af53e9d3369245e6cc3b130e78e26100d1f63cdb0abeb3d3c"},
+    {file = "psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:748c9dd2583ed86347ed65d0035f45fa8c851e8d90354c122ab72319b5f366f4"},
+    {file = "psutil-5.9.6-cp36-cp36m-win32.whl", hash = "sha256:3ebf2158c16cc69db777e3c7decb3c0f43a7af94a60d72e87b2823aebac3d602"},
+    {file = "psutil-5.9.6-cp36-cp36m-win_amd64.whl", hash = "sha256:ff18b8d1a784b810df0b0fff3bcb50ab941c3b8e2c8de5726f9c71c601c611aa"},
+    {file = "psutil-5.9.6-cp37-abi3-win32.whl", hash = "sha256:a6f01f03bf1843280f4ad16f4bde26b817847b4c1a0db59bf6419807bc5ce05c"},
+    {file = "psutil-5.9.6-cp37-abi3-win_amd64.whl", hash = "sha256:6e5fb8dc711a514da83098bc5234264e551ad980cec5f85dabf4d38ed6f15e9a"},
+    {file = "psutil-5.9.6-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:daecbcbd29b289aac14ece28eca6a3e60aa361754cf6da3dfb20d4d32b6c7f57"},
+    {file = "psutil-5.9.6.tar.gz", hash = "sha256:e4b92ddcd7dd4cdd3f900180ea1e104932c7bce234fb88976e2a3b296441225a"},
+]
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pygments"
@@ -348,5 +452,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "bed7d678b7ac7686a44a7354a80a8c2ea995903b2df0b0922cdee9a5710dbf49"
+python-versions = "^3.11"
+content-hash = "a049a3fe967e7261e9837c5ed3bb1d6f4c8cb076ba3e9e5f0bbed4c9ffe2f491"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ jinja2 = "^3.1.2"
 typer = {extras = ["all"], version = "^0.9.0"}
 pyyaml = "^6.0.1"
 requests = "^2.31.0"
+psutil = "^5.9.6"
 
 
 [build-system]


### PR DESCRIPTION
This PR:
- Solves: `fm logs <sitename>` should show frappe dev server logs #26
- Add `-f` short flag for `--follow` in `fm logs <sitename>`
- Fix port checking implementation, now using python package `psutil` for Linux and `lsof` command for osx.
- Minor status message changes and code cleanup here and there.
- Provides service name hints in help for `--service` flag in `fm logs` and `fm shell` subcommand.