### PR TITLE
Remove `restart: always`, fix app installation and auto-completion of sitenames.

### DIFF
--- a/Docker/build.sh
+++ b/Docker/build.sh
@@ -1,40 +1,47 @@
 #!/usr/bin/env bash
-TAG='v0.10.0'
+set -x
 ARCH=$(uname -m)
 
-# arm64
-if [[ "${ARCH}" == 'arm64' ]]; then
-    echo "Building arm64 Images with tag arm64-${TAG}"
-    docker build --push --platform linux/arm64 -t ghcr.io/rtcamp/frappe-manager-nginx:arm64-"${TAG}" nginx/.
-    docker build --push --platform linux/arm64 -t ghcr.io/rtcamp/frappe-manager-mailhog:arm64-"${TAG}" mailhog/.
-    docker build --push --platform linux/arm64 -t ghcr.io/rtcamp/frappe-manager-frappe:arm64-"${TAG}" frappe/.
+IMAGE_NAME_PREFIX="ghcr.io/rtcamp/frappe-manager"
+COMMAND='docker build --push'
+
+OTHER_ARCH="x86_64"
+if [[ "${ARCH}" == "x86_64" ]]; then
+    ARCH="amd64"
+    OTHER_ARCH="arm64"
 fi
 
-#amd64
-if [[ "${ARCH}" == 'x86_64' ]]; then
-    echo "Building amd64 Images with tag amd64-${TAG}"
-    docker build --push --platform linux/amd64 -t ghcr.io/rtcamp/frappe-manager-nginx:amd64-"${TAG}" nginx/.
-    docker build --push --platform linux/amd64 -t ghcr.io/rtcamp/frappe-manager-mailhog:amd64-"${TAG}" mailhog/.
-    docker build --push --platform linux/amd64 -t ghcr.io/rtcamp/frappe-manager-frappe:amd64-"${TAG}" frappe/.
+# images=$(jq -rc '. | keys[] ' images-tag.json || exit 0)
 
-    echo "Combining arm64 and amd64 tags.."
-    rm -rf ~/.docker/manifests
+images='frappe'
 
-    docker manifest create ghcr.io/rtcamp/frappe-manager-nginx:"$TAG" \
-    --amend ghcr.io/rtcamp/frappe-manager-nginx:amd64-"$TAG" \
-    --amend ghcr.io/rtcamp/frappe-manager-nginx:arm64-"$TAG"
+for image in ${images}; do
+    IMAGE_TAG=$(jq -rc ".${image}" images-tag.json || exit 0)
+    if [[ "${IMAGE_TAG:-}" ]]; then
 
-    docker manifest push ghcr.io/rtcamp/frappe-manager-nginx:"$TAG"
+        if [[ "${ARCH}" == 'arm64' ]]; then
+            COMMAND+=" --provenance false"
+        fi
 
-    docker manifest create ghcr.io/rtcamp/frappe-manager-mailhog:"$TAG" \
-    --amend ghcr.io/rtcamp/frappe-manager-mailhog:amd64-"$TAG" \
-    --amend ghcr.io/rtcamp/frappe-manager-mailhog:arm64-"$TAG"
+        IMAGE_NAME="${IMAGE_NAME_PREFIX}-${image}"
+        IMAGE_NAME_WITH_TAG="${IMAGE_NAME}:${ARCH}-${IMAGE_TAG}"
+        CONTEXT_DIR="${image}/."
 
-    docker manifest push ghcr.io/rtcamp/frappe-manager-mailhog:"$TAG"
+        echo "Building ${IMAGE_NAME_WITH_TAG}"
 
-    docker manifest create ghcr.io/rtcamp/frappe-manager-frappe:"$TAG" \
-    --amend ghcr.io/rtcamp/frappe-manager-frappe:amd64-"$TAG" \
-    --amend ghcr.io/rtcamp/frappe-manager-frappe:arm64-"$TAG"
+        COMMAND+=" --platform linux/${ARCH} -t ${IMAGE_NAME_WITH_TAG} $CONTEXT_DIR"
 
-    docker manifest push ghcr.io/rtcamp/frappe-manager-frappe:"$TAG"
-fi
+        eval "${COMMAND}"
+        STATUS="$?"
+
+
+        if [[ "${STATUS}" -eq 0 ]]; then
+            echo "Combining"
+            rm -rf ~/.docker/manifests
+            docker manifest create "${IMAGE_NAME}:${IMAGE_TAG}" \
+            --amend "${IMAGE_NAME_WITH_TAG}" \
+            --amend "${IMAGE_NAME}:${OTHER_ARCH}-${IMAGE_TAG}"
+        fi
+
+    fi
+done

--- a/Docker/frappe/helper-function.sh
+++ b/Docker/frappe/helper-function.sh
@@ -131,18 +131,18 @@ install_apps() {
 
     apps_txt=$(mktemp)
 
-    apps_list=$(ls -1 apps|| exit 0)
+    apps_list=$(ls -1 apps || exit 0)
 
     for app_name in $(echo "$apps_list"); do
         get_app_name  "$app_name"
         echo "$APP_NAME" >> "$apps_txt"
     done
 
-    cat "$apps_txt" > sites/apps.txt
+    cp "$apps_txt" sites/apps.txt
 
     # create apps_json
     for app_name in $(cat "$apps_txt" | grep -v 'frappe' || exit 0); do
-        apps_json=$(echo "$apps_json" | jq -rc --arg app_name "${APP_NAME}" '.+ [$app_name]')
+        apps_json=$(echo "$apps_json" | jq -rc --arg app_name "${app_name}" '.+ [$app_name]')
     done
 
     update_common_site_config install_apps "$apps_json" 'true'

--- a/Docker/images-tag.json
+++ b/Docker/images-tag.json
@@ -1,5 +1,5 @@
 {
-  "frappe": "v0.11.0",
+  "frappe": "v0.11.1",
   "nginx": "v0.10.0",
   "mailhog": "v0.8.3"
 }

--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -6,6 +6,7 @@ from enum import Enum
 CLI_DIR = Path.home() / "frappe"
 CLI_METADATA_PATH = CLI_DIR / ".fm.toml"
 CLI_SITES_ARCHIVE = CLI_DIR / "archived"
+CLI_LOG_DIRECTORY = CLI_DIR / 'logs'
 
 
 default_extension = [

--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -7,6 +7,7 @@ CLI_DIR = Path.home() / "frappe"
 CLI_METADATA_PATH = CLI_DIR / ".fm.toml"
 CLI_SITES_ARCHIVE = CLI_DIR / "archived"
 CLI_LOG_DIRECTORY = CLI_DIR / 'logs'
+CLI_SITES_DIRECTORY = CLI_DIR / 'sites'
 
 
 default_extension = [

--- a/frappe_manager/commands.py
+++ b/frappe_manager/commands.py
@@ -260,8 +260,6 @@ def create(
         # "extra_hosts": extra_hosts,
         "user": users,
     }
-    # turn off all previous
-    # start the docker compose
 
     sites.create_site(template_inputs,template_site=template)
 

--- a/frappe_manager/compose_manager/compose_file_exceptions.py
+++ b/frappe_manager/compose_manager/compose_file_exceptions.py
@@ -1,0 +1,11 @@
+from typing import Optional
+class ComposeFileException(Exception):
+    def __init__(
+        self,
+        error_msg: str,
+        exception: Optional[Exception] = None
+    ):
+        error_msg = f"{error_msg}"
+        if exception:
+            error_msg = f"{error_msg}\nException : {exception}"
+        super().__init__(error_msg)

--- a/frappe_manager/display_manager/DisplayManager.py
+++ b/frappe_manager/display_manager/DisplayManager.py
@@ -39,7 +39,7 @@ class DisplayManager:
         self.spinner.update(text=self.current_head)
         self.live.start()
 
-    def error(self, text: str, emoji_code: str = ":x:"):
+    def error(self, text: str,exception: Optional[Exception] = None, emoji_code: str = ":x:"):
         """
         Display an error message with an optional emoji code.
 
@@ -48,6 +48,9 @@ class DisplayManager:
             emoji_code (str, optional): The emoji code to display before the error message. Defaults to ':x:'.
         """
         self.stdout.print(f"{emoji_code} {text}")
+
+        if exception:
+            raise exception
 
     def warning(self, text: str, emoji_code: str = ":warning: "):
         """

--- a/frappe_manager/logger/log.py
+++ b/frappe_manager/logger/log.py
@@ -1,11 +1,14 @@
 import logging
 import logging.handlers
 import os
-from frappe_manager import CLI_DIR
+from frappe_manager import CLI_LOG_DIRECTORY
 import shutil
 import gzip
 from typing import Dict, Optional, Union
 from frappe_manager.display_manager.DisplayManager import richprint
+
+# Define MESSAGE log level
+CLEANUP = 25
 
 def namer(name):
     return name + ".gz"
@@ -17,10 +20,6 @@ def rotator(source, dest):
     os.remove(source)
 
 loggers: Dict[str, logging.Logger] = {}
-log_directory = CLI_DIR / 'logs'
-
-# Define MESSAGE log level
-CLEANUP = 25
 
 # "Register" new loggin level
 logging.addLevelName(CLEANUP, 'CLEANUP')
@@ -30,7 +29,7 @@ class FMLOGGER(logging.Logger):
         if self.isEnabledFor(CLEANUP):
             self._log(CLEANUP, msg, args, **kwargs)
 
-def get_logger(log_dir=log_directory, log_file_name='fm') -> logging.Logger:
+def get_logger(log_dir=CLI_LOG_DIRECTORY, log_file_name='fm') -> logging.Logger:
     """ Creates a Log File and returns Logger object """
     # Build Log File Full Path
     logPath = log_dir / f"{log_file_name}.log"

--- a/frappe_manager/main.py
+++ b/frappe_manager/main.py
@@ -2,6 +2,7 @@ import atexit
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.logger import log
 from frappe_manager.utils.helpers import check_update, remove_zombie_subprocess_process
+from frappe_manager import CLI_DIR, CLI_LOG_DIRECTORY
 from frappe_manager.utils.docker import process_opened
 from frappe_manager.commands import app
 
@@ -11,6 +12,7 @@ def cli_entrypoint():
         app()
     except Exception as e:
         logger = log.get_logger()
+        richprint.error(f"Exception Occured: Please check logs at {CLI_LOG_DIRECTORY/'fm.log'}")
         richprint.stop()
         with richprint.stdout.capture() as capture:
             richprint.stdout.print_exception(show_locals=True)

--- a/frappe_manager/main.py
+++ b/frappe_manager/main.py
@@ -12,7 +12,8 @@ def cli_entrypoint():
         app()
     except Exception as e:
         logger = log.get_logger()
-        richprint.error(f"Exception Occured: Please check logs at {CLI_LOG_DIRECTORY/'fm.log'}")
+        richprint.error(f'[red]Exception :[/red] {str(e).strip()}')
+        richprint.error(f"More info about error is logged in {CLI_LOG_DIRECTORY/'fm.log'}")
         richprint.stop()
         with richprint.stdout.capture() as capture:
             richprint.stdout.print_exception(show_locals=True)

--- a/frappe_manager/migration_manager/migration_executor.py
+++ b/frappe_manager/migration_manager/migration_executor.py
@@ -152,7 +152,7 @@ class MigrationExecutor:
                             f"[bold][red]FAILED MIGRATION VERSION[/red]:[/bold] {site_status['last_migration_version']}"
                         )
                         richprint.print(
-                            f"[bold][red]EXCEPTION[/red]:[/bold] {site_status['exception']}"
+                            f"[bold][red]EXCEPTION[/red]:[/bold] {type(site_status['exception']).__name__} - {site_status['exception']}"
                         )
 
                 richprint.print(
@@ -200,12 +200,13 @@ class MigrationExecutor:
         return True
 
     def set_site_data(
-        self, site, exception=None, migration_version: Optional[Version] = None
+        self, site, exception=None, migration_version: Optional[Version] = None, traceback_str: Optional[str] = None
     ):
         self.migrate_sites[site.name] = {
             "object": site,
             "exception": exception,
             "last_migration_version": migration_version,
+            "traceback": traceback_str,
         }
 
     def get_site_data(self, site_name):

--- a/frappe_manager/migration_manager/migrations/migrate_0_11_1.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_11_1.py
@@ -1,0 +1,127 @@
+import importlib
+from frappe_manager.migration_manager.migration_base import MigrationBase
+from frappe_manager.migration_manager.migration_exections import MigrationExceptionInSite
+from frappe_manager.migration_manager.migration_executor import MigrationExecutor
+from frappe_manager.services_manager.services import ServicesManager
+from frappe_manager.site_manager.SiteManager import Site
+from frappe_manager.site_manager.SiteManager import SiteManager
+from frappe_manager.display_manager.DisplayManager import richprint
+from frappe_manager.migration_manager.version import Version
+from frappe_manager import CLI_DIR
+
+
+class MigrationV0110(MigrationBase):
+    version = Version("0.11.1")
+
+    def __init__(self):
+        super().init()
+        self.sites_dir = CLI_DIR / "sites"
+        self.services_manager = ServicesManager(verbose=False)
+
+    def set_migration_executor(self, migration_executor: MigrationExecutor):
+        self.migration_executor = migration_executor
+
+    def up(self):
+        richprint.print(f"Started", prefix=f"[bold]v{str(self.version)}:[/bold] ")
+        self.logger.info("-" * 40)
+
+        # take backup of each of the site docker compose
+        sites_manager = SiteManager(self.sites_dir)
+        sites_manager.stop_sites()
+        sites = sites_manager.get_all_sites()
+
+        # migrate each site
+        main_error = False
+
+        for site_name, site_path in sites.items():
+            site = Site(name=site_name, path=site_path.parent)
+            if site.name in self.migration_executor.migrate_sites.keys():
+                site_info = self.migration_executor.migrate_sites[site.name]
+                if site_info["exception"]:
+                    richprint.print(f"Skipping migration for failed site {site.name}.")
+                    main_error = True
+                    continue
+
+            self.migration_executor.set_site_data(site, migration_version=self.version)
+            try:
+                self.migrate_site(site)
+            except Exception as e:
+                import traceback
+
+                traceback_str = traceback.format_exc()
+                self.logger.error(f"{site.name} [ EXCEPTION TRACEBACK ]:\n {traceback_str}")
+                richprint.update_live()
+                main_error = True
+                self.migration_executor.set_site_data(site, e, self.version, traceback_str=traceback_str)
+                self.undo_site_migrate(site)
+                site.down(volumes=False, timeout=5)
+
+        if main_error:
+            raise MigrationExceptionInSite("")
+
+        richprint.print(f"Successfull", prefix=f"[bold]v{str(self.version)}:[/bold] ")
+        self.logger.info("-" * 40)
+
+    def migrate_site(self, site):
+        richprint.print(f"Migrating site {site.name}", prefix=f"[bold]v{str(self.version)}:[/bold] ")
+
+        # backup docker compose.yml
+        self.backup_manager.backup(site.path / "docker-compose.yml", site_name=site.name)
+
+        # backup common_site_config.json
+        self.backup_manager.backup(
+            site.path / "workspace" / "frappe-bench" / "sites" / "common_site_config.json",
+            site_name=site.name,
+        )
+
+        site.down(volumes=False)
+        self.migrate_site_compose(site)
+
+    def down(self):
+        # richprint.print(f"Started",prefix=f"[ Migration v{str(self.version)} ][ROLLBACK] : ")
+        richprint.print(f"Started", prefix=f"[bold]v{str(self.version)} [ROLLBACK]:[/bold] ")
+        self.logger.info("-" * 40)
+
+        # undo each site
+        for site, exception in self.migration_executor.migrate_sites.items():
+            if not exception:
+                self.undo_site_migrate(site)
+
+        for backup in self.backup_manager.backups:
+            self.backup_manager.restore(backup, force=True)
+
+        richprint.print(f"Successfull", prefix=f"[bold]v{str(self.version)} [ROLLBACK]:[/bold] ")
+        self.logger.info("-" * 40)
+
+    def undo_site_migrate(self, site):
+        for backup in self.backup_manager.backups:
+            if backup.site == site.name:
+                self.backup_manager.restore(backup, force=True)
+
+        self.logger.info(f"Undo successfull for site: {site.name}")
+
+    def migrate_site_compose(self, site: Site):
+        status_msg = "Migrating site compose"
+        richprint.change_head(status_msg)
+
+        compose_version = site.composefile.get_version()
+        fm_version = importlib.metadata.version("frappe-manager")
+
+        if not site.composefile.exists():
+            richprint.print(f"{status_msg} {compose_version} -> {fm_version}: Failed ")
+            raise MigrationExceptionInSite(f"{site.composefile.compose_path} not found.")
+
+        # remove restart: from all the services
+        compose_yml = site.composefile.yml
+        try:
+            for service in compose_yml["services"]:
+                del compose_yml["services"][service]["restart"]
+        except KeyError as e:
+            self.logger.error(f"Not able to delete [blue]restart: always[/blue] attribute from compose file.{e}")
+            pass
+
+        site.composefile.set_version(str(self.version))
+
+        site.composefile.write_to_file()
+
+        richprint.print(f"{status_msg} {compose_version} -> {fm_version}: Done")

--- a/frappe_manager/site_manager/SiteManager.py
+++ b/frappe_manager/site_manager/SiteManager.py
@@ -42,12 +42,13 @@ class SiteManager:
 
             site_directory_exits_check_for_commands = ["create"]
 
-            if self.typer_context.invoked_subcommand in site_directory_exits_check_for_commands:
-                if sitepath.exists():
-                    richprint.exit(f"The site '{sitename}' already exists at {sitepath}. Aborting operation.")
-            else:
-                if not sitepath.exists():
-                    richprint.exit(f"The site '{sitename}' does not exist. Aborting operation.")
+            if self.typer_context:
+                if self.typer_context.invoked_subcommand in site_directory_exits_check_for_commands:
+                    if sitepath.exists():
+                        richprint.exit(f"The site '{sitename}' already exists at {sitepath}. Aborting operation.")
+                else:
+                    if not sitepath.exists():
+                        richprint.exit(f"The site '{sitename}' does not exist. Aborting operation.")
 
             self.site: Optional[Site] = Site(
                 sitepath,

--- a/frappe_manager/site_manager/SiteManager.py
+++ b/frappe_manager/site_manager/SiteManager.py
@@ -1,7 +1,6 @@
 import subprocess
 import json
 import shlex
-from ruamel.yaml import serialize
 from rich.prompt import Prompt
 import typer
 import shutil
@@ -43,21 +42,14 @@ class SiteManager:
 
             site_directory_exits_check_for_commands = ["create"]
 
-            if (
-                self.typer_context.invoked_subcommand
-                in site_directory_exits_check_for_commands
-            ):
+            if self.typer_context.invoked_subcommand in site_directory_exits_check_for_commands:
                 if sitepath.exists():
-                    richprint.exit(
-                        f"The site '{sitename}' already exists at {sitepath}. Aborting operation."
-                    )
+                    richprint.exit(f"The site '{sitename}' already exists at {sitepath}. Aborting operation.")
             else:
                 if not sitepath.exists():
-                    richprint.exit(
-                        f"The site '{sitename}' does not exist. Aborting operation."
-                    )
+                    richprint.exit(f"The site '{sitename}' does not exist. Aborting operation.")
 
-            self.site: Site = Site(
+            self.site: Optional[Site] = Site(
                 sitepath,
                 sitename,
                 verbose=self.verbose,
@@ -107,13 +99,12 @@ class SiteManager:
             for site_compose_path in site_compose:
                 docker = DockerClient(compose_file_path=site_compose_path)
                 try:
-                    output = docker.compose.stop(
-                        timeout=10, stream=not self.verbose
-                    )
+                    output = docker.compose.stop(timeout=10, stream=not self.verbose)
                     if not self.verbose:
                         richprint.live_lines(output, padding=(0, 0, 0, 2))
                 except DockerException as e:
                     richprint.exit(f"{status_text}: Failed")
+
         richprint.print(f"{status_text}: Done")
 
     def create_site(self, template_inputs: dict, template_site: bool = False):
@@ -126,55 +117,44 @@ class SiteManager:
         Returns:
             None
         """
-        self.site.validate_sitename()
+        try:
+            self.site.validate_sitename()
 
-        richprint.change_head(f"Creating Site Directory")
-        self.site.create_site_dir()
+            richprint.change_head(f"Creating Site Directory")
+            self.site.create_site_dir()
 
-        richprint.change_head(f"Generating Compose")
-        self.site.generate_compose(template_inputs)
-        self.site.create_compose_dirs()
+            richprint.change_head(f"Generating Compose")
+            self.site.generate_compose(template_inputs)
+            self.site.create_compose_dirs()
 
-        if template_site:
-            self.site.remove_secrets()
-            richprint.exit(
-                f"Created template site: {self.site.name}",
-                emoji_code=":white_check_mark:",
-            )
+            if template_site:
+                self.site.remove_secrets()
+                richprint.exit(f"Created template site: {self.site.name}", emoji_code=":white_check_mark:")
 
-        richprint.change_head(f"Starting Site")
-        self.site.start()
-        self.site.frappe_logs_till_start()
-        self.site.sync_workers_compose()
-        richprint.update_live()
+            richprint.change_head(f"Starting Site")
+            self.site.start()
+            self.site.frappe_logs_till_start()
+            self.site.sync_workers_compose()
+            richprint.update_live()
 
-        richprint.change_head(f"Checking site")
+            richprint.change_head(f"Checking site")
 
-        # check if site is created
-        if self.site.is_site_created():
+            # check if site is created
+            if not self.site.is_site_created():
+                raise Exception("Site not starting.")
+
             richprint.print(f"Creating Site: Done")
             self.site.remove_secrets()
-            self.typer_context.obj["logger"].info(
-                f"SITE_STATUS {self.site.name}: WORKING"
-            )
+            self.typer_context.obj["logger"].info(f"SITE_STATUS {self.site.name}: WORKING")
             richprint.print(f"Started site")
             self.info()
             if not ".localhost" in self.site.name:
-                richprint.print(
-                    f"Please note that You will have to add a host entry to your system's hosts file to access the site locally."
-                )
-        else:
-            self.typer_context.obj["logger"].error(
-                f"{self.site.name}: NOT WORKING"
-            )
+                richprint.print(f"Please note that You will have to add a host entry to your system's hosts file to access the site locally.")
 
+        except Exception as e:
+            self.typer_context.obj["logger"].error(f"{self.site.name}: NOT WORKING\n Exception: {e}")
             richprint.stop()
-
-            error_message = (
-                "There has been some error creating/starting the site.\n"
-                "Please check the logs at {}"
-            )
-
+            error_message = "There has been some error creating/starting the site.\n" "Please check the logs at {}"
             log_path = CLI_DIR / "logs" / "fm.log"
 
             richprint.error(error_message.format(log_path))
@@ -182,7 +162,6 @@ class SiteManager:
             remove_status = self.remove_site()
             if not remove_status:
                 self.info()
-
 
     def remove_site(self) -> bool:
         """
@@ -211,9 +190,7 @@ class SiteManager:
         sites_list = self.get_all_sites()
 
         if not sites_list:
-            richprint.exit(
-                "Seems like you haven't created any sites yet. To create a site, use the command: 'fm create <sitename>'."
-            )
+            richprint.exit("Seems like you haven't created any sites yet. To create a site, use the command: 'fm create <sitename>'.")
 
         list_table = Table(show_lines=True, show_header=True, highlight=True)
         list_table.add_column("Site")
@@ -225,9 +202,7 @@ class SiteManager:
             temp_site = Site(site_path, site_name)
 
             row_data = f"[link=http://{temp_site.name}]{temp_site.name}[/link]"
-            path_data = (
-                f"[link=file://{temp_site.path}]{temp_site.path}[/link]"
-            )
+            path_data = f"[link=file://{temp_site.path}]{temp_site.path}[/link]"
 
             status_color = "white"
             status_msg = "Inactive"
@@ -238,9 +213,7 @@ class SiteManager:
 
             status_data = f"[{status_color}]{status_msg}[/{status_color}]"
 
-            list_table.add_row(
-                row_data, status_data, path_data, style=f"{status_color}"
-            )
+            list_table.add_row(row_data, status_data, path_data, style=f"{status_color}")
             richprint.update_live(list_table, padding=(0, 0, 0, 0))
 
         richprint.stop()
@@ -263,9 +236,7 @@ class SiteManager:
         self.site.frappe_logs_till_start(status_msg="Starting Site")
         self.site.sync_workers_compose()
 
-    def attach_to_site(
-        self, user: str, extensions: List[str], debugger: bool = False
-    ):
+    def attach_to_site(self, user: str, extensions: List[str], debugger: bool = False):
         """
         Attaches to a running site's container using Visual Studio Code Remote Containers extension.
 
@@ -281,9 +252,7 @@ class SiteManager:
         vscode_path = shutil.which("code")
 
         if not vscode_path:
-            richprint.exit(
-                "Visual Studio Code binary i.e 'code' is not accessible via cli."
-            )
+            richprint.exit("Visual Studio Code binary i.e 'code' is not accessible via cli.")
 
         container_hex = self.site.get_frappe_container_hex()
 
@@ -315,12 +284,8 @@ class SiteManager:
         # check if the extension are the same if they are different then only update
         # check if customizations key available
         try:
-            extensions_previous = json.loads(
-                labels_previous["devcontainer.metadata"]
-            )
-            extensions_previous = extensions_previous[0]["customizations"][
-                "vscode"
-            ]["extensions"]
+            extensions_previous = json.loads(labels_previous["devcontainer.metadata"])
+            extensions_previous = extensions_previous[0]["customizations"]["vscode"]["extensions"]
 
         except KeyError:
             extensions_previous = []
@@ -337,7 +302,7 @@ class SiteManager:
         # sync debugger files
         if debugger:
             richprint.change_head("Sync vscode debugger configuration")
-            dot_vscode_dir = self.site.path / "workspace"/ "frappe-bench" / ".vscode"
+            dot_vscode_dir = self.site.path / "workspace" / "frappe-bench" / ".vscode"
             tasks_json_path = dot_vscode_dir / "tasks"
             launch_json_path = dot_vscode_dir / "launch"
             setting_json_path = dot_vscode_dir / "settings"
@@ -355,25 +320,18 @@ class SiteManager:
                 file_name = f"{file_path.name}.json"
                 real_file_path = file_path.parent / file_name
                 if real_file_path.exists():
-                    backup_tasks_path = (
-                        file_path.parent
-                        / f"{file_path.name}.{datetime.now().strftime('%d-%b-%y--%H-%M-%S')}.json"
-                    )
+                    backup_tasks_path = file_path.parent / f"{file_path.name}.{datetime.now().strftime('%d-%b-%y--%H-%M-%S')}.json"
                     shutil.copy2(real_file_path, backup_tasks_path)
-                    richprint.print(
-                        f"Backup previous '{file_name}' : {backup_tasks_path}"
-                    )
+                    richprint.print(f"Backup previous '{file_name}' : {backup_tasks_path}")
 
                 with open(real_file_path, "w+") as f:
                     f.write(json.dumps(dot_vscode_config[file_path]))
 
             # install black in env
             try:
-                self.site.docker.compose.exec(service='frappe',command='/workspace/frappe-bench/env/bin/pip install black',stream=True,stream_only_exit_code=True)
+                self.site.docker.compose.exec(service="frappe", command="/workspace/frappe-bench/env/bin/pip install black", stream=True, stream_only_exit_code=True)
             except DockerException as e:
-                self.typer_context.obj["logger"].error(
-                    f"black installation exception: {e}"
-                )
+                self.typer_context.obj["logger"].error(f"black installation exception: {e}")
                 richprint.warning("Not able to install black in env.")
 
             richprint.print("Sync vscode debugger configuration: Done")
@@ -383,6 +341,7 @@ class SiteManager:
 
         if output.returncode != 0:
             richprint.exit(f"Attaching to Container : Failed")
+
         richprint.print(f"Attaching to Container : Done")
 
     def logs(self, follow, service: Optional[str] = None):
@@ -399,9 +358,7 @@ class SiteManager:
                 return self.site.bench_dev_server_logs(follow)
 
             if not self.site.is_service_running(service):
-                richprint.exit(
-                    f"Cannot show logs. [blue]{self.site.name}[/blue]'s compose service '{service}' not running!"
-                )
+                richprint.exit(f"Cannot show logs. [blue]{self.site.name}[/blue]'s compose service '{service}' not running!")
 
             self.site.logs(service, follow)
 
@@ -423,9 +380,7 @@ class SiteManager:
             user = "frappe"
 
         if not self.site.is_service_running(service):
-            richprint.exit(
-                f"Cannot spawn shell. [blue]{self.site.name}[/blue]'s compose service '{service}' not running!"
-            )
+            richprint.exit(f"Cannot spawn shell. [blue]{self.site.name}[/blue]'s compose service '{service}' not running!")
 
         self.site.shell(service, user)
 
@@ -439,14 +394,7 @@ class SiteManager:
         """
 
         richprint.change_head(f"Getting site info")
-        site_config_file = (
-            self.site.path
-            / "workspace"
-            / "frappe-bench"
-            / "sites"
-            / self.site.name
-            / "site_config.json"
-        )
+        site_config_file = self.site.path / "workspace" / "frappe-bench" / "sites" / self.site.name / "site_config.json"
 
         db_user = None
         db_pass = None
@@ -457,17 +405,13 @@ class SiteManager:
                 db_user = site_config["db_name"]
                 db_pass = site_config["db_password"]
 
-        frappe_password = self.site.composefile.get_envs("frappe")[
-            "ADMIN_PASS"
-        ]
+        frappe_password = self.site.composefile.get_envs("frappe")["ADMIN_PASS"]
         services_db_info = self.services.get_database_info()
         root_db_password = services_db_info["password"]
         root_db_host = services_db_info["host"]
         root_db_user = services_db_info["user"]
 
-        site_info_table = Table(
-            show_lines=True, show_header=False, highlight=True
-        )
+        site_info_table = Table(show_lines=True, show_header=False, highlight=True)
 
         data = {
             "Site Url": f"http://{self.site.name}",
@@ -494,9 +438,7 @@ class SiteManager:
         apps_json = self.site.get_bench_installed_apps_list()
 
         if apps_json:
-            bench_apps_list_table = Table(
-                show_lines=True, show_edge=False, pad_edge=False, expand=True
-            )
+            bench_apps_list_table = Table(show_lines=True, show_edge=False, pad_edge=False, expand=True)
 
             bench_apps_list_table.add_column("App")
             bench_apps_list_table.add_column("Version")
@@ -510,9 +452,7 @@ class SiteManager:
         running_site_workers = self.site.workers.get_services_running_status()
 
         if running_site_services:
-            site_services_table = generate_services_table(
-                running_site_services
-            )
+            site_services_table = generate_services_table(running_site_services)
             site_info_table.add_row("Site Services", site_services_table)
 
         if running_site_workers:
@@ -520,14 +460,3 @@ class SiteManager:
             site_info_table.add_row("Site Workers", site_workers_table)
 
         richprint.stdout.print(site_info_table)
-
-    def migrate_site(self):
-        """
-        Migrates the site to a new environment.
-        """
-        richprint.change_head("Migrating Environment")
-
-        if not self.site.composefile.is_services_name_same_as_template():
-            self.site.down(volumes=False)
-
-        self.site.migrate_site_compose()

--- a/frappe_manager/site_manager/__init__.py
+++ b/frappe_manager/site_manager/__init__.py
@@ -38,3 +38,9 @@ VSCODE_SETTINGS_JSON = {
   },
   "black-formatter.importStrategy" : "useBundled"
 }
+
+PREBAKED_SITE_APPS= {
+    "https://github.com/frappe/frappe": "version-15",
+    "https://github.com/frappe/erpnext": "version-15",
+    "https://github.com/frappe/hrms": "version-15",
+}

--- a/frappe_manager/site_manager/__init__.py
+++ b/frappe_manager/site_manager/__init__.py
@@ -27,3 +27,14 @@ VSCODE_TASKS_JSON = {
         }
     ],
 }
+
+VSCODE_SETTINGS_JSON = {
+  "python.defaultInterpreterPath": "/workspace/frappe-bench/env/bin/python",
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.detectIndentation": True,
+    "editor.tabSize": 4,
+    "editor.insertSpaces": True,
+  },
+  "black-formatter.importStrategy" : "useBundled"
+}

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -458,7 +458,7 @@ class Site:
             with open(bench_start_log_path, "r") as bench_start_log:
                 bench_start_log_data = log_file(bench_start_log, follow=follow)
                 for line in bench_start_log_data:
-                    richprint.stdout.print(line)
+                    print(line)
         else:
             richprint.error(f"Log file not found: {bench_start_log_path}")
 

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -42,8 +42,7 @@ class Site:
         match = is_fqdn(sitename)
 
         if not match:
-            richprint.error(f"The {sitename} must follow Fully Qualified Domain Name (FQDN) format.")
-            raise SiteException(self, f"Valid FQDN site name not provided.")
+            richprint.error(f"The {sitename} must follow Fully Qualified Domain Name (FQDN) format.",exception=SiteException(self, f"Valid FQDN site name not provided."))
 
         return True
 
@@ -215,7 +214,7 @@ class Site:
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
             richprint.print(f"{status_text}: Done")
         except DockerException as e:
-            raise SiteException(self, f"{status_text}: Failed", e)
+            richprint.error(f"{status_text}: Failed",exception=e)
 
         # start workers if exists
         if self.workers.exists():
@@ -314,7 +313,7 @@ class Site:
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
             richprint.print(f"{status_text}: Done")
         except DockerException as e:
-            raise SiteException(self, f"{status_text}: Failed", e)
+            richprint.error(f"{status_text}: Failed",exception=e)
 
         # stopping worker containers
         if self.workers.exists():
@@ -346,7 +345,7 @@ class Site:
                     exit_code = richprint.live_lines(output, padding=(0, 0, 0, 2))
                 richprint.print(f"{status_text}: Done")
             except DockerException as e:
-                raise SiteException(self, f"{status_text}: Failed", e)
+                richprint.error(f"{status_text}: Failed",exception=e)
 
     def remove(self) -> bool:
         """
@@ -371,7 +370,7 @@ class Site:
                     exit_code = richprint.live_lines(output, padding=(0, 0, 0, 2))
                 richprint.print(f"Removing Containers: Done")
             except DockerException as e:
-                raise SiteException(self, f"{status_text}: Failed", e)
+                richprint.error(f"{status_text}: Failed",exception=e)
 
         richprint.change_head(f"Removing Dirs")
 

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import importlib
 import shutil
 import json
@@ -8,6 +7,7 @@ from frappe_manager.compose_manager.ComposeFile import ComposeFile
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.site_manager.site_exceptions import (
     SiteDatabaseAddUserException,
+    SiteException,
 )
 from frappe_manager.site_manager.workers_manager.SiteWorker import SiteWorkers
 from frappe_manager.utils.helpers import log_file, get_container_name_prefix
@@ -16,199 +16,100 @@ from frappe_manager.utils.site import is_fqdn
 
 
 class Site:
-    def __init__(self, path: Path, name: str, verbose: bool = False, services=None):
+    def __init__(self, path: Path, name: str, verbose: bool = False, services=None) -> None:
         self.path = path
         self.name = name
         self.quiet = not verbose
         self.services = services
-        # self.logger = log.get_logger()
         self.init()
 
     def init(self):
-        """
-        The function checks if the Docker daemon is running and exits with an error message if it is not.
-        """
         self.composefile = ComposeFile(self.path / "docker-compose.yml")
 
         self.docker = DockerClient(compose_file_path=self.composefile.compose_path)
         self.workers = SiteWorkers(self.path, self.name, self.quiet)
-        # remove this from init
+
         if self.workers.exists():
             if not self.workers.running():
                 if self.running():
                     self.workers.start()
 
     def exists(self):
-        """
-        The `exists` function checks if a file or directory exists at the specified path.
-        :return: a boolean value. If site path exits then returns `True` else `False`.
-        """
         return self.path.exists()
 
     def validate_sitename(self) -> bool:
-        """
-        The function `validate_sitename` checks if a given sitename is valid by using a regular expression
-        pattern.
-        :return: a boolean value. If the sitename is valid, it returns True. If the sitename is not valid,
-        it returns False.
-        """
         sitename = self.name
         match = is_fqdn(sitename)
 
         if not match:
-            richprint.exit(
-                f"The {sitename} must follow a single-level subdomain Fully Qualified Domain Name (FQDN) format of localhost, such as 'subdomain.localhost'."
-            )
+            richprint.error(f"The {sitename} must follow Fully Qualified Domain Name (FQDN) format.")
+            raise SiteException(self, f"Valid FQDN site name not provided.")
+
+        return True
 
     def get_frappe_container_hex(self) -> None | str:
         """
-        The function `get_frappe_container_hex` searches for a Docker container with the name containing
-        "-frappe" and returns its hexadecimal representation if found, otherwise returns None.
-        :return: either a hexadecimal string representing the name of the Frappe container, or None if no
-        Frappe container is found.
+        Returns the hexadecimal representation of the frappe container name.
+
+        Returns:
+            str: The hexadecimal representation of the frappe container name.
         """
         container_name = self.composefile.get_container_names()
         return container_name["frappe"].encode().hex()
 
-    def migrate_site_compose(self):
-        """
-        The `migrate_site` function checks the environment version and migrates it if necessary.
-        :return: a boolean value,`True` if the site migrated else `False`.
-        """
-        if self.composefile.exists():
-            richprint.change_head("Checking Environment Version")
-            compose_version = self.composefile.get_version()
-            fm_version = importlib.metadata.version("frappe-manager")
-            if not compose_version == fm_version:
-                status = False
-                if self.composefile.exists():
-                    # get all the payloads
-                    envs = self.composefile.get_all_envs()
-                    labels = self.composefile.get_all_labels()
-
-                    # introduced in v0.10.0
-                    if not "ENVIRONMENT" in envs["frappe"]:
-                        envs["frappe"]["ENVIRONMENT"] = "dev"
-
-                    envs["frappe"]["CONTAINER_NAME_PREFIX"] = get_container_name_prefix(
-                        self.name
-                    )
-                    envs["frappe"]["MARIADB_ROOT_PASS"] = "root"
-
-                    envs["nginx"]["VIRTUAL_HOST"] = self.name
-
-                    import os
-
-                    envs_user_info = {}
-                    userid_groupid: dict = {
-                        "USERID": os.getuid(),
-                        "USERGROUP": os.getgid(),
-                    }
-
-                    env_user_info_container_list = ["frappe", "schedule", "socketio"]
-
-                    for env in env_user_info_container_list:
-                        envs_user_info[env] = deepcopy(userid_groupid)
-
-                    # overwrite user for each invocation
-                    users = {"nginx": {"uid": os.getuid(), "gid": os.getgid()}}
-
-                    # load template
-                    self.composefile.yml = self.composefile.load_template()
-
-                    # set all the payload
-                    self.composefile.set_all_envs(envs)
-                    self.composefile.set_all_envs(envs_user_info)
-                    self.composefile.set_all_labels(labels)
-                    self.composefile.set_all_users(users)
-                    # self.composefile.set_all_extrahosts(extrahosts)
-
-                    self.create_compose_dirs()
-                    self.composefile.set_network_alias(
-                        "nginx", "site-network", [self.name]
-                    )
-
-                    self.composefile.set_secret_file_path(
-                        "db_root_password",
-                        self.services.composefile.get_secret_file_path(
-                            "db_root_password"
-                        ),
-                    )
-
-                    self.composefile.set_container_names(
-                        get_container_name_prefix(self.name)
-                    )
-                    fm_version = importlib.metadata.version("frappe-manager")
-                    self.composefile.set_version(fm_version)
-                    self.composefile.set_top_networks_name(
-                        "site-network", get_container_name_prefix(self.name)
-                    )
-                    self.composefile.write_to_file()
-
-                    # change the node socketio port
-                    # self.common_site_config_set('socketio_port','80')
-                    status = True
-
-                if status:
-                    richprint.print(
-                        f"Environment Migration Done: {compose_version} -> {fm_version}"
-                    )
-                else:
-                    richprint.print(
-                        f"Environment Migration Failed: {compose_version} -> {fm_version}"
-                    )
-            else:
-                richprint.print("Already Latest Environment Version")
-
     def common_site_config_set(self, config: dict):
-        common_site_config_path = (
-            self.path / "workspace/frappe-bench/sites/common_site_config.json"
-        )
-        if common_site_config_path.exists():
-            common_site_config = {}
+        """
+        Sets the values in the common_site_config.json file.
 
-            with open(common_site_config_path, "r") as f:
-                common_site_config = json.load(f)
+        Args:
+            config (dict): A dictionary containing the key-value pairs to be set in the common_site_config.json file.
 
-            try:
-                for key, value in config.items():
-                    common_site_config[key] = value
-                with open(common_site_config_path, "w") as f:
-                    json.dump(common_site_config, f)
-                return True
-            except KeyError as e:
-                # log error that not able to change common site config
-                return False
-        else:
+        Returns:
+            bool: True if the values are successfully set, False otherwise.
+        """
+        common_site_config_path = self.path / "workspace/frappe-bench/sites/common_site_config.json"
+
+        if not common_site_config_path.exists():
+            return False
+
+        common_site_config = {}
+
+        with open(common_site_config_path, "r") as f:
+            common_site_config = json.load(f)
+
+        try:
+            for key, value in config.items():
+                common_site_config[key] = value
+            with open(common_site_config_path, "w") as f:
+                json.dump(common_site_config, f)
+            return True
+        except KeyError as e:
             return False
 
     def generate_compose(self, inputs: dict) -> None:
         """
-        The function `generate_compose` sets environment variables, extra hosts, and version information in
-        a compose file and writes it to a file.
+        Generates the compose file for the site based on the given inputs.
 
-        :param inputs: The `inputs` parameter is a dictionary that contains the values which will be used in compose file.
-        :type inputs: dict
+        Args:
+            inputs (dict): A dictionary containing the inputs for generating the compose file.
+
+        Returns:
+            None
         """
-        try:
-            if "environment" in inputs.keys():
-                environments: dict = inputs["environment"]
-                self.composefile.set_all_envs(environments)
+        if "environment" in inputs.keys():
+            environments: dict = inputs["environment"]
+            self.composefile.set_all_envs(environments)
 
-            if "labels" in inputs.keys():
-                labels: dict = inputs["labels"]
-                self.composefile.set_all_labels(labels)
+        if "labels" in inputs.keys():
+            labels: dict = inputs["labels"]
+            self.composefile.set_all_labels(labels)
 
-            # handle user
-            if "user" in inputs.keys():
-                user: dict = inputs["user"]
-                for container_name in user.keys():
-                    uid = user[container_name]["uid"]
-                    gid = user[container_name]["gid"]
-                    self.composefile.set_user(container_name, uid, gid)
-
-        except Exception as e:
-            richprint.exit(f"Not able to generate site compose. Error: {e}")
+        if "user" in inputs.keys():
+            user: dict = inputs["user"]
+            for container_name in user.keys():
+                uid = user[container_name]["uid"]
+                gid = user[container_name]["gid"]
+                self.composefile.set_user(container_name, uid, gid)
 
         self.composefile.set_network_alias("nginx", "site-network", [self.name])
         self.composefile.set_container_names(get_container_name_prefix(self.name))
@@ -216,43 +117,45 @@ class Site:
             "db_root_password",
             self.services.composefile.get_secret_file_path("db_root_password"),
         )
+
         fm_version = importlib.metadata.version("frappe-manager")
+
         self.composefile.set_version(fm_version)
-        self.composefile.set_top_networks_name(
-            "site-network", get_container_name_prefix(self.name)
-        )
+        self.composefile.set_top_networks_name("site-network", get_container_name_prefix(self.name))
         self.composefile.write_to_file()
 
     def create_site_dir(self):
-        # create site dir
         self.path.mkdir(parents=True, exist_ok=True)
 
     def sync_site_common_site_config(self):
+        """
+        Syncs the common site configuration with the global database information and container prefix.
+
+        This function sets the common site configuration data including the socketio port, database host and port,
+        and the Redis cache, queue, and socketio URLs.
+        """
         global_db_info = self.services.get_database_info()
-        global_db_host = global_db_info["host"]
-        global_db_port = global_db_info["port"]
+        container_prefix = get_container_name_prefix(self.name)
 
         # set common site config
         common_site_config_data = {
             "socketio_port": "80",
-            "db_host": global_db_host,
-            "db_port": global_db_port,
-            "redis_cache": f"redis://{get_container_name_prefix(self.name)}-redis-cache:6379",
-            "redis_queue": f"redis://{get_container_name_prefix(self.name)}-redis-queue:6379",
-            "redis_socketio": f"redis://{get_container_name_prefix(self.name)}-redis-cache:6379",
+            "db_host": global_db_info["host"],
+            "db_port": global_db_info["port"],
+            "redis_cache": f"redis://{container_prefix}-redis-cache:6379",
+            "redis_queue": f"redis://{container_prefix}-redis-queue:6379",
+            "redis_socketio": f"redis://{container_prefix}-redis-cache:6379",
         }
         self.common_site_config_set(common_site_config_data)
 
     def create_compose_dirs(self) -> bool:
         """
-        The function `create_dirs` creates two directories, `workspace` and `certs`, within a specified
-        path.
+        Creates the necessary directories for the Compose setup.
+
+        Returns:
+            bool: True if the directories are created successfully, False otherwise.
         """
         richprint.change_head("Creating Compose directories")
-
-        # create compose bind dirs -> workspace
-        # create compose bind dirs -> workspace
-        # create workspace from frappe image
 
         frappe_image = self.composefile.yml["services"]["frappe"]["image"]
 
@@ -294,29 +197,35 @@ class Site:
 
         richprint.print("Creating Compose directories: Done")
 
+        return True
+
     def start(self) -> bool:
         """
-        The function starts Docker containers and prints the status of the operation.
+        Starts the Docker containers for the site.
+
+        Returns:
+            bool: True if the containers were started successfully, False otherwise.
         """
         status_text = "Starting Docker Containers"
         richprint.change_head(status_text)
+
         try:
-            output = self.docker.compose.up(
-                detach=True, pull="never", stream=self.quiet
-            )
+            output = self.docker.compose.up(detach=True, pull="never", stream=self.quiet)
             if self.quiet:
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
             richprint.print(f"{status_text}: Done")
         except DockerException as e:
-            richprint.exit(f"{status_text}: Failed", error_msg=e)
+            raise SiteException(self, f"{status_text}: Failed", e)
 
-        # start workers if exits
+        # start workers if exists
         if self.workers.exists():
             self.workers.start()
 
+        return True
+
     def pull(self):
         """
-        The function pulls Docker images and displays the status of the operation.
+        Pull docker images.
         """
         status_text = "Pulling Docker Images"
         richprint.change_head(status_text)
@@ -332,22 +241,13 @@ class Site:
 
     def logs(self, service: str, follow: bool = False):
         """
-        The `logs` function prints the logs of a specified service, with the option to follow the logs in
-        real-time.
+        Retrieve and print the logs for a specific service.
 
-        :param service: The "service" parameter is a string that specifies the name of the service whose
-        logs you want to retrieve. It is used to filter the logs and only retrieve the logs for that
-        specific service
-        :type service: str
-        :param follow: The `follow` parameter is a boolean flag that determines whether to continuously
-        stream the logs or not. If `follow` is set to `True`, the logs will be streamed continuously as they
-        are generated. If `follow` is set to `False`, only the existing logs will be returned, defaults to
-        False
-        :type follow: bool (optional)
+        Args:
+            service (str): The name of the service.
+            follow (bool, optional): Whether to continuously follow the logs. Defaults to False.
         """
-        output = self.docker.compose.logs(
-            services=[service], no_log_prefix=True, follow=follow, stream=True
-        )
+        output = self.docker.compose.logs(services=[service], no_log_prefix=True, follow=follow, stream=True)
         for source, line in output:
             line = line.decode()
             if source == "stdout":
@@ -358,7 +258,10 @@ class Site:
 
     def frappe_logs_till_start(self, status_msg=None):
         """
-        The function `frappe_logs_till_start` prints logs until a specific line is found and then stops.
+        Retrieves and prints the logs of the 'frappe' service until site supervisor starts.
+
+        Args:
+            status_msg (str, optional): Custom status message to display. Defaults to None.
         """
         status_text = "Creating Site"
 
@@ -368,7 +271,10 @@ class Site:
         richprint.change_head(status_text)
         try:
             output = self.docker.compose.logs(
-                services=["frappe"], no_log_prefix=True, follow=True, stream=True
+                services=["frappe"],
+                no_log_prefix=True,
+                follow=True,
+                stream=True,
             )
 
             if self.quiet:
@@ -395,8 +301,10 @@ class Site:
 
     def stop(self) -> bool:
         """
-        The `stop` function stops containers and prints the status of the operation using the `richprint`
-        module.
+        Stop the site by stopping the containers.
+
+        Returns:
+            bool: True if the site is successfully stopped, False otherwise.
         """
         status_text = "Stopping Containers"
         richprint.change_head(status_text)
@@ -406,7 +314,7 @@ class Site:
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
             richprint.print(f"{status_text}: Done")
         except DockerException as e:
-            richprint.exit(f"{status_text}: Failed")
+            raise SiteException(self, f"{status_text}: Failed", e)
 
         # stopping worker containers
         if self.workers.exists():
@@ -414,7 +322,15 @@ class Site:
 
     def down(self, remove_ophans=True, volumes=True, timeout=5) -> bool:
         """
-        The `down` function removes containers using Docker Compose and prints the status of the operation.
+        Stops and removes the containers for the site.
+
+        Args:
+            remove_ophans (bool, optional): Whether to remove orphan containers. Defaults to True.
+            volumes (bool, optional): Whether to remove volumes. Defaults to True.
+            timeout (int, optional): Timeout in seconds for stopping the containers. Defaults to 5.
+
+        Returns:
+            bool: True if the containers were successfully stopped and removed, False otherwise.
         """
         if self.composefile.exists():
             status_text = "Removing Containers"
@@ -430,53 +346,67 @@ class Site:
                     exit_code = richprint.live_lines(output, padding=(0, 0, 0, 2))
                 richprint.print(f"{status_text}: Done")
             except DockerException as e:
-                richprint.exit(f"{status_text}: Failed")
+                raise SiteException(self, f"{status_text}: Failed", e)
 
     def remove(self) -> bool:
         """
-        The `remove` function removes containers and then recursively  site directories.
+        Removes the site by stopping and removing the containers associated with it,
+        and deleting the site directory.
+
+        Returns:
+            bool: True if the site is successfully removed, False otherwise.
         """
-        # TODO handle low leverl error like read only, write only etc
+        # TODO handle low level errors like read only, write only, etc.
         if self.composefile.exists():
             status_text = "Removing Containers"
             richprint.change_head(status_text)
             try:
                 output = self.docker.compose.down(
-                    remove_orphans=True, volumes=True, timeout=2, stream=self.quiet
+                    remove_orphans=True,
+                    volumes=True,
+                    timeout=2,
+                    stream=self.quiet,
                 )
                 if self.quiet:
                     exit_code = richprint.live_lines(output, padding=(0, 0, 0, 2))
                 richprint.print(f"Removing Containers: Done")
             except DockerException as e:
-                richprint.exit(f"{status_text}: Failed")
+                raise SiteException(self, f"{status_text}: Failed", e)
+
         richprint.change_head(f"Removing Dirs")
 
         try:
             shutil.rmtree(self.path)
         except PermissionError as e:
             images = self.composefile.get_all_images()
-            if 'frappe' in images:
+            if "frappe" in images:
                 try:
-                    frappe_image = images['frappe']
+                    frappe_image = images["frappe"]
                     frappe_image = f"{frappe_image['name']}:{frappe_image['tag']}"
-                    output = self.docker.run(image=frappe_image,entrypoint="/bin/sh",command="-c 'chown -R frappe:frappe .'",volume=f'{self.path}/workspace:/workspace',stream=True, stream_only_exit_code=True)
+                    output = self.docker.run(
+                        image=frappe_image,
+                        entrypoint="/bin/sh",
+                        command="-c 'chown -R frappe:frappe .'",
+                        volume=f"{self.path}/workspace:/workspace",
+                        stream=True,
+                        stream_only_exit_code=True,
+                    )
+
                     shutil.rmtree(self.path)
+
                 except Exception:
                     richprint.error(e)
                     richprint.exit(f"Please remove {self.path} manually")
+
         richprint.change_head(f"Removing Dirs: Done")
 
     def shell(self, container: str, user: str | None = None):
         """
-        The `shell` function spawns a shell for a specified container and user.
+        Open a shell inside a Docker container.
 
-        :param container: The `container` parameter is a string that specifies the name of the container in
-        which the shell command will be executed
-        :type container: str
-        :param user: The `user` parameter is an optional argument that specifies the user under which the
-        shell command should be executed. If a user is provided, the shell command will be executed as that
-        user. If no user is provided, the shell command will be executed as the default user
-        :type user: str | None
+        Args:
+            container (str): The name of the Docker container.
+            user (str, optional): The user to run the shell as. Defaults to None.
         """
         richprint.stop()
 
@@ -484,14 +414,14 @@ class Site:
 
         shell_path = "/bin/bash" if container not in non_bash_supported else "sh"
 
-        exec_args = {'service': container, 'command': shell_path}
+        exec_args = {"service": container, "command": shell_path}
 
         if container == "frappe":
-            exec_args['command'] = "/usr/bin/zsh"
-            exec_args['workdir']= '/workspace/frappe-bench'
+            exec_args["command"] = "/usr/bin/zsh"
+            exec_args["workdir"] = "/workspace/frappe-bench"
 
         if user:
-            exec_args['user'] = user
+            exec_args["user"] = user
 
         try:
             self.docker.compose.exec(**exec_args)
@@ -518,12 +448,12 @@ class Site:
 
     def bench_dev_server_logs(self, follow=False):
         """
-        This function is used to tail logs found at /workspace/logs/bench-start.log.
-        :param follow: Bool detemines whether to follow the log file for changes
+        Display the logs of the development server in the Frappe Bench.
+
+        Args:
+            follow (bool, optional): Whether to continuously follow the logs. Defaults to False.
         """
-        bench_start_log_path = (
-            self.path / "workspace" / "frappe-bench" / "logs" / "web.dev.log"
-        )
+        bench_start_log_path = self.path / "workspace" / "frappe-bench" / "logs" / "web.dev.log"
 
         if bench_start_log_path.exists() and bench_start_log_path.is_file():
             with open(bench_start_log_path, "r") as bench_start_log:
@@ -534,6 +464,16 @@ class Site:
             richprint.error(f"Log file not found: {bench_start_log_path}")
 
     def is_site_created(self, retry=60, interval=1) -> bool:
+        """
+        Checks if the site is created and accessible.
+
+        Args:
+            retry (int): Number of times to retry the check.
+            interval (int): Interval between each retry in seconds.
+
+        Returns:
+            bool: True if the site is created and accessible, False otherwise.
+        """
         from time import sleep
 
         for _ in range(retry):
@@ -542,11 +482,11 @@ class Site:
                 result = self.docker.compose.exec(
                     service="frappe",
                     command=f"curl -I --max-time {retry} --connect-timeout {retry} http://localhost",
-                    stream = True
+                    stream=True,
                 )
 
                 # Check if the site is working
-                for source , line in result:
+                for source, line in result:
                     if "HTTP/1.1 200 OK" in line.decode():
                         return True
             except Exception as e:
@@ -556,33 +496,39 @@ class Site:
 
     def running(self) -> bool:
         """
-        The `running` function checks if all the services defined in a Docker Compose file are running.
-        :return: a boolean value. If the number of running containers is greater than or equal to the number
-        of services listed in the compose file, it returns True. Otherwise, it returns False.
+        Check if all services specified in the compose file are running.
+
+        Returns:
+            bool: True if all services are running, False otherwise.
         """
         services = self.composefile.get_services_list()
         running_status = self.get_services_running_status()
 
-        if running_status:
-            for service in services:
-                try:
-                    if not running_status[service] == "running":
-                        return False
-                except KeyError:
-                    return False
-        else:
+        if not running_status:
             return False
+
+        for service in services:
+            try:
+                if not running_status[service] == "running":
+                    return False
+            except KeyError:
+                return False
+
         return True
 
     def get_services_running_status(self) -> dict:
+        """
+        Get the running status of services in the Docker Compose file.
 
+        Returns:
+            A dictionary containing the running status of services.
+            The keys are the service names, and the values are the container states.
+        """
         services = self.composefile.get_services_list()
         containers = self.composefile.get_container_names().values()
         services_status = {}
         try:
-            output = self.docker.compose.ps(
-                service=services, format="json", all=True, stream=True
-            )
+            output = self.docker.compose.ps(service=services, format="json", all=True, stream=True)
             status: list = []
             for source, line in output:
                 if source == "stdout":
@@ -601,6 +547,12 @@ class Site:
             return {}
 
     def get_host_port_binds(self):
+        """
+        Get the list of published ports on the host for all containers.
+
+        Returns:
+            list: A list of published ports on the host.
+        """
         try:
             output = self.docker.compose.ps(all=True, format="json", stream=True)
             status: list = []
@@ -638,8 +590,7 @@ class Site:
         running_status = self.get_services_running_status()
         if running_status[service] == "running":
             return True
-        else:
-            return False
+        return False
 
     def sync_workers_compose(self):
         self.regenerate_supervisor_conf()
@@ -690,9 +641,7 @@ class Site:
                 )
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
 
-                generate_split_config_command = (
-                    "/scripts/divide-supervisor-conf.py config/supervisor.conf"
-                )
+                generate_split_config_command = "/scripts/divide-supervisor-conf.py config/supervisor.conf"
 
                 output = self.docker.compose.exec(
                     service="frappe",
@@ -705,14 +654,14 @@ class Site:
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
 
                 return True
+
             except DockerException as e:
                 richprint.error(f"Failure in generating, supervisor.conf file.{e}")
 
                 if backup:
                     richprint.print("Rolling back to previous workers configuration.")
                     shutil.copy(
-                        self.workers.supervisor_config_path.parent
-                        / "supervisor.conf.bak",
+                        self.workers.supervisor_config_path.parent / "supervisor.conf.bak",
                         self.workers.supervisor_config_path,
                     )
 
@@ -722,31 +671,18 @@ class Site:
                 return False
 
     def get_bench_installed_apps_list(self):
-        apps_json_file = (
-            self.path / "workspace" / "frappe-bench" / "sites" / "apps.json"
-        )
-
+        apps_json_file = self.path / "workspace" / "frappe-bench" / "sites" / "apps.json"
         apps_data: dict = {}
-
         if not apps_json_file.exists():
             return {}
-
         with open(apps_json_file, "r") as f:
             apps_data = json.load(f)
-
         return apps_data
 
     def get_site_db_info(self):
         db_info = {}
 
-        site_config_file = (
-            self.path
-            / "workspace"
-            / "frappe-bench"
-            / "sites"
-            / self.name
-            / "site_config.json"
-        )
+        site_config_file = self.path / "workspace" / "frappe-bench" / "sites" / self.name / "site_config.json"
 
         if site_config_file.exists():
             with open(site_config_file, "r") as f:
@@ -773,7 +709,7 @@ class Site:
         add_db_user = f"/usr/bin/mariadb -h{db_host} -P3306 -u{db_user} -p'{db_password}' -e 'CREATE USER `{site_db_user}`@`%` IDENTIFIED BY \"{site_db_pass}\";'"
         grant_user = f"/usr/bin/mariadb -h{db_host} -P3306 -u{db_user} -p'{db_password}' -e 'GRANT ALL PRIVILEGES ON `{site_db_name}`.* TO `{site_db_user}`@`%`;'"
         SHOW_db_user = f"/usr/bin/mariadb -P3306-h{db_host} -u{db_user} -p'{db_password}' -e 'SELECT User, Host FROM mysql.user;'"
-        #
+
         import time
 
         check_connection_command = f"/usr/bin/mariadb -h{db_host} -u{db_user} -p'{db_password}' -e 'SHOW DATABASES;'"
@@ -800,9 +736,7 @@ class Site:
             i += 1
 
         if not connected:
-            raise SiteDatabaseAddUserException(
-                self.name, f"Not able to start db: {error}"
-            )
+            raise SiteDatabaseAddUserException(self.name, f"Not able to start db: {error}")
 
         removed = True
         try:
@@ -833,9 +767,7 @@ class Site:
                 )
                 richprint.print(f"Recreated user {site_db_user}")
             except DockerException as e:
-                raise SiteDatabaseAddUserException(
-                    self.name, f"Database user creation failed: {e}"
-                )
+                raise SiteDatabaseAddUserException(self.name, f"Database user creation failed: {e}")
 
     def remove_secrets(self):
         richprint.print(f"Removing Secrets", emoji_code=":construction:")
@@ -852,7 +784,7 @@ class Site:
 
         if running:
             self.start()
-            self.frappe_logs_till_start(status_msg='Starting Site')
+            self.frappe_logs_till_start(status_msg="Starting Site")
 
         richprint.print(f"Removing Secrets: Done")
 

--- a/frappe_manager/site_manager/site_exceptions.py
+++ b/frappe_manager/site_manager/site_exceptions.py
@@ -3,10 +3,11 @@ from typing import List, Optional
 class SiteException(Exception):
     def __init__(
         self,
-            site,
+        site,
         error_msg: str,
+        exception: Optional[Exception] = None
     ):
-        error_msg = f"{site.name}: {error_msg}"
+        error_msg = f"{self.name}: {error_msg}"
         super().__init__(error_msg)
 
 class SiteWorkerNotStart(Exception):

--- a/frappe_manager/site_manager/site_exceptions.py
+++ b/frappe_manager/site_manager/site_exceptions.py
@@ -7,7 +7,7 @@ class SiteException(Exception):
         error_msg: str,
         exception: Optional[Exception] = None
     ):
-        error_msg = f"{self.name}: {error_msg}"
+        error_msg = f"{site.name}: {error_msg}"
         super().__init__(error_msg)
 
 class SiteWorkerNotStart(Exception):

--- a/frappe_manager/templates/docker-compose.tmpl
+++ b/frappe_manager/templates/docker-compose.tmpl
@@ -3,7 +3,6 @@ services:
   frappe:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     environment:
       ADMIN_PASS: REPLACE_me_with_frappe_web_admin_pass
       # apps are defined as <app-name>:<branch-name>, if branch name not given then default github branch will be used.
@@ -33,7 +32,6 @@ services:
     image: ghcr.io/rtcamp/frappe-manager-nginx:v0.10.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     user: REPLACE_ME_WITH_CURRENT_USER:REPLACE_ME_WITH_CURRENT_USER_GROUP
-    restart: always
     environment:
       # not implemented as of now
       ENABLE_SSL: REPLACE_ME_WITH_TOGGLE_ENABLE_SSL
@@ -56,7 +54,6 @@ services:
   mailhog:
     image: ghcr.io/rtcamp/frappe-manager-mailhog:v0.8.3
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     expose:
       - 1025
       - 8025
@@ -66,7 +63,6 @@ services:
   adminer:
     image: adminer:latest
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     environment:
       ADMINER_DEFAULT_SERVER: global-db
     expose:
@@ -78,7 +74,6 @@ services:
   socketio:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     environment:
       TIMEOUT: 60000
       CHANGE_DIR: /workspace/frappe-bench/logs
@@ -97,7 +92,6 @@ services:
   schedule:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     environment:
       TIMEOUT: 60000
       CHANGE_DIR: /workspace/frappe-bench
@@ -115,7 +109,6 @@ services:
   redis-cache:
     image: redis:alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     volumes:
       - redis-cache-data:/data
     expose:
@@ -126,7 +119,6 @@ services:
   redis-queue:
     image: redis:alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     volumes:
       - redis-queue-data:/data
     expose:
@@ -137,7 +129,6 @@ services:
   redis-socketio:
     image: redis:alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
-    restart: always
     volumes:
        - redis-socketio-data:/data
     expose:

--- a/frappe_manager/templates/docker-compose.workers.tmpl
+++ b/frappe_manager/templates/docker-compose.workers.tmpl
@@ -1,7 +1,6 @@
 services:
   worker-name:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
-    restart: always
     environment:
       TIMEOUT: 6000
       CHANGE_DIR: /workspace/frappe-bench

--- a/frappe_manager/utils/callbacks.py
+++ b/frappe_manager/utils/callbacks.py
@@ -1,8 +1,10 @@
 import typer
+from pathlib import Path
 from typing import List, Optional
+from frappe_manager.site_manager.SiteManager import SiteManager
 from frappe_manager.utils.helpers import check_frappe_app_exists, get_current_fm_version
 from frappe_manager.display_manager.DisplayManager import richprint
-from frappe_manager import STABLE_APP_BRANCH_MAPPING_LIST
+from frappe_manager import CLI_SITES_DIRECTORY, STABLE_APP_BRANCH_MAPPING_LIST
 
 
 def apps_list_validation_callback(value: List[str] | None):
@@ -109,3 +111,9 @@ def version_callback(version: Optional[bool] = None):
         fm_version = get_current_fm_version()
         richprint.print(fm_version, emoji_code='')
         raise typer.Exit()
+
+
+def sites_autocompletion_callback():
+    sites = SiteManager(CLI_SITES_DIRECTORY)
+    sites_list = sites.get_all_sites()
+    return sites_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "frappe-manager"
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT"
 repository = "https://github.com/rtcamp/frappe-manager"
 description = "A CLI tool based on Docker Compose to easily manage Frappe based projects. As of now, only suitable for development in local machines running on Mac and Linux based OS."
@@ -10,7 +10,7 @@ documentation = "https://github.com/rtcamp/frappe-manager/wiki"
 readme = "README.md"
 
 [tool.black]
-line-length = 79
+line-length = 200
 inline-quotes = "'"
 
 [tool.poetry.urls]
@@ -26,6 +26,9 @@ requests = "^2.31.0"
 psutil = "^5.9.6"
 ruamel-yaml = "^0.18.5"
 tomlkit = "^0.12.3"
+
+[tool.pyright]
+reportOptionalMemberAccess = false
 
 
 [build-system]


### PR DESCRIPTION
This PR:

- removes `restart: always` 
- fix app installation when providing it using `-a` flag in `create` command.
- support for auto-completion for sitenames.