### PR TITLE
Detect sitename in sites directory, `--force` flag for `start` command and update migrations

### DIFF
--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -10,7 +10,7 @@ CLI_LOG_DIRECTORY = CLI_DIR / 'logs'
 CLI_SITES_DIRECTORY = CLI_DIR / 'sites'
 
 
-default_extension = [
+DEFAULT_EXTENSIONS = [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "ms-python.python",

--- a/frappe_manager/commands.py
+++ b/frappe_manager/commands.py
@@ -10,17 +10,25 @@ import shutil
 import importlib
 import json
 
-from typing import Annotated, List, Optional, Set
+from typing import Annotated, List, Optional
 from frappe_manager.services_manager.services_exceptions import ServicesNotCreated
 from frappe_manager.site_manager.SiteManager import SiteManager
 from frappe_manager.display_manager.DisplayManager import richprint
-from frappe_manager import CLI_DIR, default_extension, SiteServicesEnum, services_manager, CLI_SITES_DIRECTORY
-from frappe_manager.docker_wrapper import DockerClient, DockerException
+from frappe_manager import CLI_DIR, DEFAULT_EXTENSIONS, SiteServicesEnum, services_manager, CLI_SITES_DIRECTORY
+from frappe_manager.docker_wrapper.DockerClient import DockerClient
+from frappe_manager.docker_wrapper.DockerException import DockerException
 from frappe_manager.logger import log
 from frappe_manager.services_manager.services import ServicesManager
 from frappe_manager.migration_manager.migration_executor import MigrationExecutor
 from frappe_manager.site_manager.site_exceptions import SiteException
-from frappe_manager.utils.callbacks import apps_list_validation_callback, frappe_branch_validation_callback, sites_autocompletion_callback, version_callback
+from frappe_manager.utils.callbacks import (
+    apps_list_validation_callback,
+    frappe_branch_validation_callback,
+    sites_autocompletion_callback,
+    version_callback,
+    sitename_callback,
+    code_command_extensions_callback,
+)
 from frappe_manager.utils.helpers import get_container_name_prefix, is_cli_help_called, get_current_fm_version
 from frappe_manager.services_manager.commands import services_app
 from frappe_manager.sub_commands.self_commands import self_app
@@ -28,20 +36,19 @@ from frappe_manager.metadata_manager import MetadataManager
 from frappe_manager.migration_manager.version import Version
 from frappe_manager.compose_manager.ComposeFile import ComposeFile
 
-app = typer.Typer(no_args_is_help=True,rich_markup_mode='rich')
+app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich")
 app.add_typer(services_app, name="services", help="Handle global services.")
 app.add_typer(self_app, name="self", help="Perform operations related to the [bold][blue]fm[/bold][/blue] itself.")
 
 # this will be initiated later in the app_callback
 sites: Optional[SiteManager] = None
 
+
 @app.callback()
 def app_callback(
-        ctx: typer.Context,
-        verbose: Annotated[Optional[bool], typer.Option('--verbose','-v',help="Enable verbose output.")] = None,
-        version: Annotated[
-            Optional[bool], typer.Option("--version",help="Show Version.",callback=version_callback)
-        ] = None,
+    ctx: typer.Context,
+    verbose: Annotated[Optional[bool], typer.Option("--verbose", "-v", help="Enable verbose output.")] = None,
+    version: Annotated[Optional[bool], typer.Option("--version", help="Show Version.", callback=version_callback)] = None,
 ):
     """
     Frappe-Manager for creating frappe development envrionments.
@@ -53,7 +60,6 @@ def app_callback(
     ctx.obj["is_help_called"] = help_called
 
     if not help_called:
-
         first_time_install = False
 
         richprint.start(f"Working")
@@ -72,14 +78,13 @@ def app_callback(
         # logging
         global logger
         logger = log.get_logger()
-        logger.info('')
+        logger.info("")
         logger.info(f"{':'*20}FM Invoked{':'*20}")
-        logger.info('')
+        logger.info("")
 
         # logging command provided by user
         logger.info(f"RUNNING COMMAND: {' '.join(sys.argv[1:])}")
-        logger.info('-'*20)
-
+        logger.info("-" * 20)
 
         # check docker daemon service
         if not DockerClient().server_running():
@@ -91,8 +96,8 @@ def app_callback(
         if first_time_install:
             if not metadata_manager.toml_file.exists():
                 richprint.print("🔍 It seems like the first installation. Pulling images... 🖼️")
-                site_composefile = ComposeFile(loadfile=Path('docker-compose.yml'))
-                services_composefile = ComposeFile(loadfile=Path('docker-compose.services.yml',template='docker-compose.services.tmpl'))
+                site_composefile = ComposeFile(loadfile=Path("docker-compose.yml"))
+                services_composefile = ComposeFile(loadfile=Path("docker-compose.services.yml", template="docker-compose.services.tmpl"))
                 images_list = []
                 docker = DockerClient()
 
@@ -100,7 +105,7 @@ def app_callback(
                     images = site_composefile.get_all_images()
                     images.update(services_composefile.get_all_images())
 
-                    for service ,image_info in images.items():
+                    for service, image_info in images.items():
                         image = f"{image_info['name']}:{image_info['tag']}"
                         images_list.append(image)
 
@@ -111,9 +116,9 @@ def app_callback(
 
                     for image in images_list:
                         status = f"[blue]Pulling image[/blue] [bold][yellow]{image}[/yellow][/bold]"
-                        richprint.change_head(status,style=None)
+                        richprint.change_head(status, style=None)
                         try:
-                            output = docker.pull(container_name=image , stream=True)
+                            output = docker.pull(container_name=image, stream=True)
                             richprint.live_lines(output, padding=(0, 0, 0, 2))
                             richprint.print(f"{status} : Done")
                         except DockerException as e:
@@ -124,12 +129,12 @@ def app_callback(
                             # richprint.error(f"[red][bold]Error :[/bold][/red] {e}")
 
                     if error:
-                        print('')
+                        print("")
                         richprint.error(f"[bold][red]Pulling images failed for these images[/bold][/red]")
-                        for image,exception in images_dict.items():
+                        for image, exception in images_dict.items():
                             if exception:
-                                richprint.error(f'[bold][red]Image [/bold][/red]: {image}')
-                                richprint.error(f'[bold][red]Error [/bold][/red]: {exception}')
+                                richprint.error(f"[bold][red]Image [/bold][/red]: {image}")
+                                richprint.error(f"[bold][red]Error [/bold][/red]: {exception}")
                         shutil.rmtree(CLI_DIR)
                         richprint.exit("Aborting. [bold][blue]fm[/blue][/bold] will not be able to work without images. 🖼️")
 
@@ -167,27 +172,21 @@ def app_callback(
         ctx.obj["services"] = services_manager
 
 
-
 @app.command(no_args_is_help=True)
 def create(
     sitename: Annotated[str, typer.Argument(help="Name of the site")],
     apps: Annotated[
         Optional[List[str]],
         typer.Option(
-            "--apps", "-a", help="FrappeVerse apps to install. App should be specified in format <appname>:<branch> or <appname>.", callback=apps_list_validation_callback,
-            show_default=False
+            "--apps", "-a", help="FrappeVerse apps to install. App should be specified in format <appname>:<branch> or <appname>.", callback=apps_list_validation_callback, show_default=False
         ),
     ] = None,
     developer_mode: Annotated[bool, typer.Option(help="Enable developer mode")] = True,
-    frappe_branch: Annotated[
-        str, typer.Option(help="Specify the branch name for frappe app",callback=frappe_branch_validation_callback)
-    ] = "version-15",
+    frappe_branch: Annotated[str, typer.Option(help="Specify the branch name for frappe app", callback=frappe_branch_validation_callback)] = "version-15",
     template: Annotated[bool, typer.Option(help="Create template site.")] = False,
     admin_pass: Annotated[
         str,
-        typer.Option(
-            help="Default Password for the standard 'Administrator' User. This will be used as the password for the Administrator User for all new sites"
-        ),
+        typer.Option(help="Default Password for the standard 'Administrator' User. This will be used as the password for the Administrator User for all new sites"),
     ] = "admin",
     enable_ssl: Annotated[bool, typer.Option(help="Enable https")] = False,
 ):
@@ -227,8 +226,8 @@ def create(
             "ADMIN_PASS": admin_pass,
             "DB_NAME": sites.site.name.replace(".", "-"),
             "SITENAME": sites.site.name,
-            "MARIADB_HOST" : 'global-db',
-            "MARIADB_ROOT_PASS": '/run/secrets/db_root_password',
+            "MARIADB_HOST": "global-db",
+            "MARIADB_ROOT_PASS": "/run/secrets/db_root_password",
             "CONTAINER_NAME_PREFIX": get_container_name_prefix(sites.site.name),
             "ENVIRONMENT": "dev",
         },
@@ -306,47 +305,48 @@ def code(
             help="List of extensions to install in vscode at startup.Provide extension id eg: ms-python.python",
             callback=code_command_extensions_callback,
         ),
-    ] = default_extension,
-    force_start: Annotated[bool , typer.Option('--force-start','-f',help="Force start the site before attaching to container.")] = False,
-    debugger: Annotated[bool , typer.Option('--debugger','-d',help="Sync vscode debugger configuration.")] = False
+    ] = DEFAULT_EXTENSIONS,
+    force_start: Annotated[bool, typer.Option("--force-start", "-f", help="Force start the site before attaching to container.")] = False,
+    debugger: Annotated[bool, typer.Option("--debugger", "-d", help="Sync vscode debugger configuration.")] = False,
 ):
-    """Open site in vscode. """
+    """Open site in vscode."""
     sites.init(sitename)
     if force_start:
         sites.start_site()
     sites.attach_to_site(user, extensions, debugger)
 
 
-@app.command(no_args_is_help=True)
+@app.command()
 def logs(
-    sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)],
+    sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None,
     service: Annotated[Optional[SiteServicesEnum], typer.Option(help="Specify service name to show container logs.")] = None,
-    follow: Annotated[bool, typer.Option('--follow','-f',help="Follow logs.")] = False,
+    follow: Annotated[bool, typer.Option("--follow", "-f", help="Follow logs.")] = False,
 ):
-    """Show frappe dev server logs or container logs for a given site. """
+    """Show frappe dev server logs or container logs for a given site."""
     sites.init(sitename)
     if service:
-        sites.logs(service=SiteServicesEnum(service).value,follow=follow)
+        sites.logs(service=SiteServicesEnum(service).value, follow=follow)
     else:
         sites.logs(follow=follow)
 
 
-@app.command(no_args_is_help=True)
+@app.command()
 def shell(
-    sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)],
-    user: Annotated[str, typer.Option(help="Connect as this user.")] = None,
-    service: Annotated[SiteServicesEnum, typer.Option(help="Specify Service")] = 'frappe',
+    sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None,
+    user: Annotated[Optional[str], typer.Option(help="Connect as this user.")] = None,
+    service: Annotated[SiteServicesEnum, typer.Option(help="Specify Service")] = "frappe",
 ):
-    """Open shell for the give site. """
+    """Open shell for the give site."""
     sites.init(sitename)
     if service:
-        sites.shell(service=SiteServicesEnum(service).value,user=user)
+        sites.shell(service=SiteServicesEnum(service).value, user=user)
     else:
         sites.shell(user=user)
 
-@app.command(no_args_is_help=True)
+
+@app.command()
 def info(
-    sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)],
+    sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None,
 ):
     """Shows information about given site."""
     sites.init(sitename)

--- a/frappe_manager/commands.py
+++ b/frappe_manager/commands.py
@@ -260,47 +260,43 @@ def create(
         "user": users,
     }
 
-    sites.create_site(template_inputs,template_site=template)
+    sites.create_site(template_inputs, template_site=template)
 
 
-@app.command(no_args_is_help=True)
-def delete(sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)]):
-    """Delete a site. """
+@app.command()
+def delete(sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None):
+    """Delete a site."""
     sites.init(sitename)
     sites.remove_site()
 
 
 @app.command()
 def list():
-    """Lists all of the available sites. """
+    """Lists all of the available sites."""
     sites.init()
     sites.list_sites()
 
 
-@app.command(no_args_is_help=True)
-def start(sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)]):
-    """Start a site. """
+@app.command()
+def start(
+    sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None,
+    force: Annotated[bool, typer.Option("--force", "-f", help="Force recreate site containers")] = False,
+):
+    """Start a site."""
     sites.init(sitename)
-    sites.start_site()
+    sites.start_site(force=force)
 
 
-@app.command(no_args_is_help=True)
-def stop(sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)]):
-    """Stop a site. """
+@app.command()
+def stop(sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None):
+    """Stop a site."""
     sites.init(sitename)
     sites.stop_site()
 
 
-def code_command_extensions_callback(extensions: List[str]) -> List[str]:
-    extx = extensions + default_extension
-    unique_ext: Set = set(extx)
-    unique_ext_list: List[str] = [x for x in unique_ext]
-    return unique_ext_list
-
-
-@app.command(no_args_is_help=True)
+@app.command()
 def code(
-    sitename: Annotated[str, typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback)],
+    sitename: Annotated[Optional[str], typer.Argument(help="Name of the site.", autocompletion=sites_autocompletion_callback, callback=sitename_callback)] = None,
     user: Annotated[str, typer.Option(help="Connect as this user.")] = "frappe",
     extensions: Annotated[
         Optional[List[str]],

--- a/frappe_manager/docker_wrapper/DockerCompose.py
+++ b/frappe_manager/docker_wrapper/DockerCompose.py
@@ -41,6 +41,7 @@ class DockerComposeWrapper:
         build: bool = False,
         remove_orphans: bool = False,
         no_recreate: bool = False,
+        force_recreate: bool = False,
         always_recreate_deps: bool = False,
         quiet_pull: bool = False,
         pull: Literal["missing", "never", "always"] = "missing",

--- a/frappe_manager/docker_wrapper/__init__.py
+++ b/frappe_manager/docker_wrapper/__init__.py
@@ -1,2 +1,0 @@
-from .DockerClient import DockerClient
-from .DockerException import DockerException

--- a/frappe_manager/main.py
+++ b/frappe_manager/main.py
@@ -2,10 +2,9 @@ import atexit
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.logger import log
 from frappe_manager.utils.helpers import check_update, remove_zombie_subprocess_process
-from frappe_manager import CLI_DIR, CLI_LOG_DIRECTORY
+from frappe_manager import CLI_LOG_DIRECTORY
 from frappe_manager.utils.docker import process_opened
 from frappe_manager.commands import app
-
 
 def cli_entrypoint():
     try:

--- a/frappe_manager/migration_manager/migrations/migrate_0_10_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_10_0.py
@@ -1,7 +1,7 @@
 import shutil
 from copy import deepcopy
 from pathlib import Path
-from frappe_manager.docker_wrapper import DockerException
+from frappe_manager.docker_wrapper.DockerException import DockerException
 from frappe_manager.migration_manager.backup_manager import BackupData
 from frappe_manager.migration_manager.migration_base import MigrationBase
 from frappe_manager import CLI_DIR

--- a/frappe_manager/services_manager/services.py
+++ b/frappe_manager/services_manager/services.py
@@ -19,7 +19,8 @@ from frappe_manager.utils.helpers import (
 
 )
 from frappe_manager.utils.docker import host_run_cp
-from frappe_manager.docker_wrapper import DockerClient, DockerException
+from frappe_manager.docker_wrapper.DockerClient import DockerClient
+from frappe_manager.docker_wrapper.DockerException import DockerException
 
 
 class ServicesManager:

--- a/frappe_manager/site_manager/SiteManager.py
+++ b/frappe_manager/site_manager/SiteManager.py
@@ -133,7 +133,7 @@ class SiteManager:
                 richprint.exit(f"Created template site: {self.site.name}", emoji_code=":white_check_mark:")
 
             richprint.change_head(f"Starting Site")
-            self.site.start()
+            self.site.start(force=True)
             self.site.frappe_logs_till_start()
             self.site.sync_workers_compose()
             richprint.update_live()
@@ -228,12 +228,12 @@ class SiteManager:
         self.site.stop()
         richprint.print(f"Stopped site")
 
-    def start_site(self):
+    def start_site(self,force: bool = False):
         """
         Starts the site.
         """
         self.site.sync_site_common_site_config()
-        self.site.start()
+        self.site.start(force=force)
         self.site.frappe_logs_till_start(status_msg="Starting Site")
         self.site.sync_workers_compose()
 

--- a/frappe_manager/site_manager/SiteManager.py
+++ b/frappe_manager/site_manager/SiteManager.py
@@ -11,9 +11,11 @@ from datetime import datetime
 from frappe_manager.site_manager import VSCODE_LAUNCH_JSON, VSCODE_TASKS_JSON, VSCODE_SETTINGS_JSON
 from frappe_manager.site_manager.site import Site
 from frappe_manager.display_manager.DisplayManager import richprint
-from frappe_manager.docker_wrapper import DockerClient, DockerException
+from frappe_manager.docker_wrapper.DockerClient import DockerClient
+from frappe_manager.docker_wrapper.DockerException import DockerException
 from frappe_manager import CLI_DIR
 from rich.table import Table
+from frappe_manager.utils.helpers import get_sitename_from_current_path
 from frappe_manager.utils.site import generate_services_table, domain_level
 
 from frappe_manager.utils.site import generate_services_table

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -198,7 +198,7 @@ class Site:
 
         return True
 
-    def start(self) -> bool:
+    def start(self,force: bool = False) -> bool:
         """
         Starts the Docker containers for the site.
 
@@ -209,7 +209,7 @@ class Site:
         richprint.change_head(status_text)
 
         try:
-            output = self.docker.compose.up(detach=True, pull="never", stream=self.quiet)
+            output = self.docker.compose.up(detach=True, pull="never",force_recreate=force, stream=self.quiet)
             if self.quiet:
                 richprint.live_lines(output, padding=(0, 0, 0, 2))
             richprint.print(f"{status_text}: Done")

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -2,7 +2,8 @@ import importlib
 import shutil
 import json
 from pathlib import Path
-from frappe_manager.docker_wrapper import DockerClient, DockerException
+from frappe_manager.docker_wrapper.DockerClient import DockerClient
+from frappe_manager.docker_wrapper.DockerException import DockerException
 from frappe_manager.compose_manager.ComposeFile import ComposeFile
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.site_manager.site_exceptions import (

--- a/frappe_manager/site_manager/workers_manager/SiteWorker.py
+++ b/frappe_manager/site_manager/workers_manager/SiteWorker.py
@@ -3,11 +3,11 @@ import json
 from copy import deepcopy
 
 from frappe_manager.site_manager.site_exceptions import SiteWorkerNotStart
-from rich import inspect
 from frappe_manager.compose_manager.ComposeFile import ComposeFile
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.utils.helpers import get_container_name_prefix
-from frappe_manager.docker_wrapper import DockerClient, DockerException
+from frappe_manager.docker_wrapper.DockerClient import DockerClient
+from frappe_manager.docker_wrapper.DockerException import DockerException
 
 class SiteWorkers:
     def __init__(self,site_path, site_name, quiet: bool = True):

--- a/frappe_manager/sub_commands/update_command.py
+++ b/frappe_manager/sub_commands/update_command.py
@@ -5,7 +5,8 @@ import json
 from rich.prompt import Prompt
 from pathlib import Path
 from frappe_manager.compose_manager.ComposeFile import ComposeFile
-from frappe_manager.docker_wrapper import DockerClient, DockerException
+from frappe_manager.docker_wrapper.DockerClient import DockerClient
+from frappe_manager.docker_wrapper.DockerException import DockerException
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.utils.helpers import install_package
 

--- a/frappe_manager/templates/docker-compose.tmpl
+++ b/frappe_manager/templates/docker-compose.tmpl
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   frappe:
-    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
+    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.1
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     environment:
       ADMIN_PASS: REPLACE_me_with_frappe_web_admin_pass
@@ -72,7 +72,7 @@ services:
       global-backend-network:
 
   socketio:
-    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
+    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.1
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     environment:
       TIMEOUT: 60000
@@ -90,7 +90,7 @@ services:
       site-network:
 
   schedule:
-    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
+    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.1
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     environment:
       TIMEOUT: 60000

--- a/frappe_manager/templates/docker-compose.workers.tmpl
+++ b/frappe_manager/templates/docker-compose.workers.tmpl
@@ -1,6 +1,6 @@
 services:
   worker-name:
-    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.0
+    image: ghcr.io/rtcamp/frappe-manager-frappe:v0.11.1
     environment:
       TIMEOUT: 6000
       CHANGE_DIR: /workspace/frappe-bench

--- a/frappe_manager/utils/callbacks.py
+++ b/frappe_manager/utils/callbacks.py
@@ -1,10 +1,10 @@
 import typer
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Set
 from frappe_manager.site_manager.SiteManager import SiteManager
-from frappe_manager.utils.helpers import check_frappe_app_exists, get_current_fm_version
+from frappe_manager.utils.helpers import check_frappe_app_exists, get_current_fm_version, get_sitename_from_current_path
 from frappe_manager.display_manager.DisplayManager import richprint
-from frappe_manager import CLI_SITES_DIRECTORY, STABLE_APP_BRANCH_MAPPING_LIST
+from frappe_manager import CLI_SITES_DIRECTORY, STABLE_APP_BRANCH_MAPPING_LIST, DEFAULT_EXTENSIONS
 
 
 def apps_list_validation_callback(value: List[str] | None):
@@ -29,10 +29,9 @@ def apps_list_validation_callback(value: List[str] | None):
             if appx == "frappe":
                 raise typer.BadParameter("'frappe' should not be included here.")
 
-            if 'https:' in app or 'http:' in app:
+            if "https:" in app or "http:" in app:
                 temp_appx = appx
                 appx = [":".join(appx[:2])]
-
 
                 if len(temp_appx) == 3:
                     appx.append(temp_appx[2])
@@ -43,14 +42,10 @@ def apps_list_validation_callback(value: List[str] | None):
 
             if len(appx) > 2:
                 richprint.stop()
-                msg = (
-                    "Specify the app in the format <appname>:<branch> or <appname>."
-                    "\n<appname> can be a URL or, if it's a FrappeVerse app, simply provide it as 'erpnext' or 'hrms:develop'."
-                )
+                msg = "Specify the app in the format <appname>:<branch> or <appname>." "\n<appname> can be a URL or, if it's a FrappeVerse app, simply provide it as 'erpnext' or 'hrms:develop'."
                 raise typer.BadParameter(msg)
 
             if len(appx) == 1:
-
                 exists = check_frappe_app_exists(appx[0])
 
                 if not exists["app"]:
@@ -61,7 +56,6 @@ def apps_list_validation_callback(value: List[str] | None):
                     appx.append(STABLE_APP_BRANCH_MAPPING_LIST[appx[0]])
 
             if len(appx) == 2:
-
                 exists = check_frappe_app_exists(appx[0], appx[1])
 
                 if not exists["app"]:
@@ -70,10 +64,7 @@ def apps_list_validation_callback(value: List[str] | None):
 
                 if not exists["branch"]:
                     richprint.stop()
-                    raise typer.BadParameter(
-                        f"Invaid branch '{appx[1]}' for '{appx[0]}'."
-                    )
-
+                    raise typer.BadParameter(f"Invaid branch '{appx[1]}' for '{appx[0]}'.")
 
             appx = ":".join(appx)
             apps_list.append(appx)
@@ -95,10 +86,11 @@ def frappe_branch_validation_callback(value: str):
     """
     if value:
         exists = check_frappe_app_exists("frappe", value)
-        if exists['branch']:
+        if exists["branch"]:
             return value
         else:
             raise typer.BadParameter(f"Frappe branch -> {value} is not valid!! ")
+
 
 def version_callback(version: Optional[bool] = None):
     """
@@ -109,7 +101,7 @@ def version_callback(version: Optional[bool] = None):
     """
     if version:
         fm_version = get_current_fm_version()
-        richprint.print(fm_version, emoji_code='')
+        richprint.print(fm_version, emoji_code="")
         raise typer.Exit()
 
 
@@ -117,3 +109,20 @@ def sites_autocompletion_callback():
     sites = SiteManager(CLI_SITES_DIRECTORY)
     sites_list = sites.get_all_sites()
     return sites_list
+
+
+def sitename_callback(sitename):
+    if not sitename:
+        sitename = get_sitename_from_current_path()
+
+    if not sitename:
+        raise typer.BadParameter(message="Missing Argument")
+
+    return sitename
+
+
+def code_command_extensions_callback(extensions: List[str]) -> List[str]:
+    extx = extensions + DEFAULT_EXTENSIONS
+    unique_ext: Set = set(extx)
+    unique_ext_list: List[str] = [x for x in unique_ext]
+    return unique_ext_list

--- a/frappe_manager/utils/helpers.py
+++ b/frappe_manager/utils/helpers.py
@@ -10,10 +10,11 @@ import secrets
 import grp
 
 from pathlib import Path
+from frappe_manager.utils.site import is_fqdn
 from frappe_manager.logger import log
-from frappe_manager.docker_wrapper.DockerException import DockerException
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.site_manager import PREBAKED_SITE_APPS
+from frappe_manager import CLI_SITES_DIRECTORY
 
 
 def remove_zombie_subprocess_process(process):
@@ -32,6 +33,7 @@ def remove_zombie_subprocess_process(process):
         logger.cleanup(f"PROCESS: USED PROCESS {process}")
 
         import psutil
+
         for pid in process:
             try:
                 process = psutil.Process(pid)
@@ -57,7 +59,7 @@ def check_update():
         latest_version = update_info["info"]["version"]
         if not fm_version == latest_version:
             richprint.warning(
-                f'[dim]Update available v{latest_version}.[/dim]',
+                f"[dim]Update available v{latest_version}.[/dim]",
                 emoji_code=":arrows_counterclockwise:️",
             )
     except Exception as e:
@@ -101,9 +103,7 @@ def check_ports(ports):
             # check port using lsof command
             cmd = f"lsof -iTCP:{port} -sTCP:LISTEN -P -n"
             try:
-                output = subprocess.run(
-                    cmd, check=True, shell=True, capture_output=True
-                )
+                output = subprocess.run(cmd, check=True, shell=True, capture_output=True)
                 if output.returncode == 0:
                     already_binded.append(port)
             except subprocess.CalledProcessError as e:
@@ -154,7 +154,6 @@ def generate_random_text(length=50):
     return "".join(random.choice(alphanumeric_chars) for _ in range(length))
 
 
-
 def is_cli_help_called(ctx):
     """
     Checks if the help is called for the CLI command.
@@ -168,17 +167,12 @@ def is_cli_help_called(ctx):
     help_called = False
     # is called command is sub command group
     try:
-        for subtyper_command in ctx.command.commands[
-            ctx.invoked_subcommand
-        ].commands.keys():
+        for subtyper_command in ctx.command.commands[ctx.invoked_subcommand].commands.keys():
             check_command = " ".join(sys.argv[2:])
             if check_command == subtyper_command:
-                if (
-                    ctx.command.commands[ctx.invoked_subcommand]
-                    .commands[subtyper_command]
-                    .params
-                ):
+                if ctx.command.commands[ctx.invoked_subcommand].commands[subtyper_command].params:
                     help_called = True
+
     except AttributeError:
         help_called = False
 
@@ -188,11 +182,14 @@ def is_cli_help_called(ctx):
 
         if check_command == ctx.invoked_subcommand:
             # is called command supports arguments then help called
-
             if ctx.command.commands[ctx.invoked_subcommand].params:
                 help_called = True
 
+            if not ctx.command.commands[ctx.invoked_subcommand].no_args_is_help:
+                help_called = False
+
     return help_called
+
 
 def get_current_fm_version():
     """
@@ -203,7 +200,8 @@ def get_current_fm_version():
     """
     return importlib.metadata.version("frappe-manager")
 
-def check_repo_exists(app_url:str, branch_name: str | None = None, exclude_dict: dict[str,str] = PREBAKED_SITE_APPS ):
+
+def check_repo_exists(app_url: str, branch_name: str | None = None, exclude_dict: dict[str, str] = PREBAKED_SITE_APPS):
     """
     Check if a Frappe app exists on GitHub.
 
@@ -220,7 +218,6 @@ def check_repo_exists(app_url:str, branch_name: str | None = None, exclude_dict:
         else:
             app = requests.get(app_url).status_code
 
-
         if branch_name:
             if branch_name in exclude_dict.values():
                 branch = 200
@@ -235,14 +232,14 @@ def check_repo_exists(app_url:str, branch_name: str | None = None, exclude_dict:
         return {"app": True if app == 200 else False}
 
     except Exception as e:
-        richprint.error(f"Not able to validate app {app_url} for branch [blue]{branch_name}[/blue]",e)
+        richprint.error(f"Not able to validate app {app_url} for branch [blue]{branch_name}[/blue]", e)
+
 
 def check_frappe_app_exists(app: str, branch_name: Optional[str] = None):
+    if "github.com" not in app:
+        app = f"https://github.com/frappe/{app}"
 
-    if 'github.com' not in app:
-        app= f"https://github.com/frappe/{app}"
-
-    return check_repo_exists(app_url=app,branch_name=branch_name)
+    return check_repo_exists(app_url=app, branch_name=branch_name)
 
 
 def represent_null_empty(string_null):
@@ -255,11 +252,11 @@ def represent_null_empty(string_null):
     Returns:
         str: The modified string with "null" replaced by an empty string.
     """
-    return string_null.replace("null","")
+    return string_null.replace("null", "")
 
 
-def log_file(file, refresh_time:float = 0.1, follow:bool =False):
-    '''
+def log_file(file, refresh_time: float = 0.1, follow: bool = False):
+    """
     Generator function that yields new lines in a file
 
     Parameters:
@@ -269,7 +266,7 @@ def log_file(file, refresh_time:float = 0.1, follow:bool =False):
 
     Returns:
     - A generator that yields each new line in the file
-    '''
+    """
     file.seek(0)
 
     # start infinite loop
@@ -282,8 +279,9 @@ def log_file(file, refresh_time:float = 0.1, follow:bool =False):
             # sleep if file hasn't been updated
             time.sleep(refresh_time)
             continue
-        line = line.strip('\n')
+        line = line.strip("\n")
         yield line
+
 
 def get_container_name_prefix(site_name):
     """
@@ -295,7 +293,8 @@ def get_container_name_prefix(site_name):
     Returns:
         str: The container name prefix.
     """
-    return site_name.replace('.', '')
+    return site_name.replace(".", "")
+
 
 def random_password_generate(password_length=13, symbols=False):
     # Define the character set to include symbols
@@ -308,13 +307,11 @@ def random_password_generate(password_length=13, symbols=False):
 
     # Replace some characters with symbols in the generated password
     if symbols:
-        password = "".join(
-            c if secrets.choice([True, False]) else secrets.choice(symbols)
-            for c in generated_password
-        )
+        password = "".join(c if secrets.choice([True, False]) else secrets.choice(symbols) for c in generated_password)
         return password
 
     return generated_password
+
 
 # Retrieve Unix groups and their corresponding integer mappings
 def get_unix_groups():
@@ -324,5 +321,23 @@ def get_unix_groups():
         groups[group_name] = group_entry.gr_gid
     return groups
 
+
 def install_package(package_name, version):
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', f'{package_name}=={version}'])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", f"{package_name}=={version}"])
+
+
+def get_sitename_from_current_path() -> Optional[str]:
+    current_path = Path().absolute()
+    sites_path = CLI_SITES_DIRECTORY.absolute()
+
+    if not current_path.is_relative_to(sites_path):
+        return None
+
+    sitename_list = list(current_path.relative_to(sites_path).parts)
+
+    if not sitename_list:
+        return None
+
+    sitename = sitename_list[0]
+    if is_fqdn(sitename):
+        return sitename


### PR DESCRIPTION
This PR:

- Sitename is now detected when the `fm` is ran from respective site directory.
- Introduces `--force` flag to `start` command for force recreate containers.
- Updates template and migration for workers compose file.