### PR TITLE
Fix `code` command force start flag and `create` command template flag

### DIFF
--- a/frappe_manager/migration_manager/migration_base.py
+++ b/frappe_manager/migration_manager/migration_base.py
@@ -159,7 +159,7 @@ class MigrationBase(ABC):
         bench_db_info = bench.get_db_connection_info()
         bench_db_name = bench_db_info["name"]
 
-        richprint.change_head(f'Commencing db [blue]{bench.name}[/blue] backup')
+        richprint.change_head(f'Commencing db {bench.name} backup')
 
         mariadb_manager = MariaDBManager(server_db_info, services_manager.compose_project)
 

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -192,7 +192,11 @@ class Bench:
 
             if is_template_bench:
                 self.remove_attached_secrets()
-                richprint.exit(f"Created template bench: {self.name}", emoji_code=":white_check_mark:")
+                global_db_info = self.services.database_manager.database_server_info
+                self.sync_bench_common_site_config(global_db_info.host, global_db_info.port)
+                self.save_bench_config()
+                richprint.print(f"Created template bench: {self.name}", emoji_code=":white_check_mark:")
+                return
 
             richprint.change_head(f"Starting bench services")
             self.compose_project.start_service(force_recreate=True)
@@ -219,19 +223,7 @@ class Bench:
 
             self.logger.info(f"{self.name}: Bench site is active and responding.")
 
-            # self.create_certificate()
-
-            # richprint.change_head("Configuring bench admin tools.")
-
-            # if self.bench_config.admin_tools:
-            #     self.sync_admin_tools_compose()
-            #     self.restart_frappe_server()
-
-            # richprint.print("Cofigured bench admin tools.")
-
             self.info()
-
-            # self.save_bench_config()
 
             if not ".localhost" in self.name:
                 richprint.print(

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -17,7 +17,6 @@ from frappe_manager.logger import log
 from frappe_manager.migration_manager.backup_manager import BackupManager
 from frappe_manager.services_manager.services import ServicesManager
 from frappe_manager.site_manager import VSCODE_LAUNCH_JSON, VSCODE_SETTINGS_JSON, VSCODE_TASKS_JSON
-from frappe_manager.site_manager import bench_config
 from frappe_manager.site_manager.admin_tools import AdminTools
 from frappe_manager.site_manager.bench_config import BenchConfig, FMBenchEnvType
 from frappe_manager.site_manager.site_exceptions import (
@@ -415,6 +414,7 @@ class Bench:
         self.sync_bench_common_site_config(global_db_info.host, global_db_info.port)
 
         richprint.change_head("Starting bench services")
+        self.admin_tools.remove_nginx_location_config()
         self.compose_project.start_service(force_recreate=force)
         self.sync_bench_config_configuration()
         self.save_bench_config()
@@ -425,12 +425,6 @@ class Bench:
             richprint.change_head("Starting bench workers services")
             self.workers.compose_project.start_service(force_recreate=force)
             richprint.print("Started bench workers services.")
-
-        # # start admin_tools if exists
-        # if self.admin_tools.compose_project.compose_file_manager.exists():
-        #     richprint.change_head("Starting bench admin tools services")
-        #     self.admin_tools.compose_project.start_service(force_recreate=force)
-        #     richprint.print("Started bench admin tools services.")
 
         richprint.change_head('Starting frappe server')
         self.frappe_logs_till_start()
@@ -966,7 +960,7 @@ class Bench:
             self.compose_project.compose_file_manager.set_labels("frappe", labels)
             self.compose_project.compose_file_manager.write_to_file()
             richprint.print(f"Regenerated bench compose.")
-            self.start()
+            self.compose_project.start_service(['frappe'])
 
         # sync debugger files
         if debugger:


### PR DESCRIPTION
This PR:
- Fixes `code` command force start flag where the bench was starting twice when using the force start flag.
- Fixes `create` command template flag where FM error-ed out when using this flag.