### PR TITLE
Add Cloudflare Let's Encrypt DNS challenge support

### DIFF
--- a/frappe_manager/commands.py
+++ b/frappe_manager/commands.py
@@ -25,7 +25,7 @@ from frappe_manager.services_manager.services import ServicesManager
 from frappe_manager.migration_manager.migration_executor import MigrationExecutor
 from frappe_manager.site_manager.site import Bench
 from frappe_manager.site_manager.workers_manager.SiteWorker import BenchWorkers
-from frappe_manager.ssl_manager import SUPPORTED_SSL_TYPES
+from frappe_manager.ssl_manager import LETSENCRYPT_PREFERRED_CHALLENGE, SUPPORTED_SSL_TYPES
 from frappe_manager.ssl_manager.certificate import SSLCertificate
 from frappe_manager.ssl_manager.letsencrypt_certificate import LetsencryptSSLCertificate
 from frappe_manager.utils.callbacks import (
@@ -156,6 +156,14 @@ def create(
     environment: Annotated[
         FMBenchEnvType, typer.Option("--environment", "--env", help="Select bench environment type.")
     ] = FMBenchEnvType.dev,
+    letsencrypt_preferred_challenge: Annotated[
+        Optional[LETSENCRYPT_PREFERRED_CHALLENGE],
+        typer.Option(help="Select preferred letsencrypt challenge.", show_default=False),
+    ] = None,
+    letsencrypt_email: Annotated[
+        Optional[str],
+        typer.Option(help="Specify email for letsencrypt", show_default=False),
+    ] = None,
     developer_mode: Annotated[
         EnableDisableOptionsEnum, typer.Option(help="Toggle frappe developer mode.")
     ] = EnableDisableOptionsEnum.disable,
@@ -205,18 +213,36 @@ def create(
     bench_config_path = bench_path / CLI_BENCH_CONFIG_FILE_NAME
 
     if ssl == SUPPORTED_SSL_TYPES.le:
-        if fm_config_manager.le_email == 'dummy@fm.fm':
-            email = richprint.prompt_ask(prompt='Please enter [bold][green]email[/bold][/green] for Let\'s Encrypt')
-            validate_email(email, check_deliverability=False)
-            fm_config_manager.le_email = email
-            fm_config_manager.export_to_toml()
-            richprint.print("Let's Encrypt email saved to configuration. It will be used automatically from now on.")
-        else:
-            richprint.print("Using Let's Encrypt email from configuration.")
-            email = fm_config_manager.le_email
-            fm_config_manager.export_to_toml()
+        if not letsencrypt_preferred_challenge:
+            if fm_config_manager.letsencrypt.exists:
+                if letsencrypt_preferred_challenge is None:
+                    letsencrypt_preferred_challenge = LETSENCRYPT_PREFERRED_CHALLENGE.dns01
 
-        ssl_certificate = LetsencryptSSLCertificate(domain=benchname, ssl_type=ssl, email=email)
+            if not letsencrypt_preferred_challenge:
+                letsencrypt_preferred_challenge = LETSENCRYPT_PREFERRED_CHALLENGE.http01
+
+        if fm_config_manager.letsencrypt.email == 'dummy@fm.fm' or fm_config_manager.letsencrypt.email is None:
+            if not letsencrypt_email:
+                richprint.stop()
+                raise typer.BadParameter("No email provided, required by certbot.", param_hint='--letsencrypt-email')
+            else:
+                email = letsencrypt_email
+
+            validate_email(email, check_deliverability=False)
+        else:
+            richprint.print(
+                "Defaulting to Let's Encrypt email from [blue]fm_config.toml[/blue] since [blue]'--letsencrypt-email'[/blue] is not given."
+            )
+            email = fm_config_manager.letsencrypt.email
+
+        ssl_certificate = LetsencryptSSLCertificate(
+            domain=benchname,
+            ssl_type=ssl,
+            email=email,
+            preferred_challenge=letsencrypt_preferred_challenge,
+            api_key=fm_config_manager.letsencrypt.api_key,
+            api_token=fm_config_manager.letsencrypt.api_token,
+        )
 
     elif ssl == SUPPORTED_SSL_TYPES.none:
         ssl_certificate = SSLCertificate(domain=benchname, ssl_type=ssl)
@@ -483,9 +509,17 @@ def update(
         Optional[EnableDisableOptionsEnum],
         typer.Option("--admin-tools", help="Toggle admin-tools.", show_default=False),
     ] = None,
+    letsencrypt_preferred_challenge: Annotated[
+        Optional[LETSENCRYPT_PREFERRED_CHALLENGE],
+        typer.Option(help="Select preferred letsencrypt challenge.", show_default=False),
+    ] = None,
+    letsencrypt_email: Annotated[
+        Optional[str],
+        typer.Option(help="Specify email for letsencrypt", show_default=False),
+    ] = None,
     environment: Annotated[
         Optional[FMBenchEnvType],
-        typer.Option("--environment", help="Switch bench environment.", show_default=False),
+        typer.Option("--environment", "--env", help="Switch bench environment.", show_default=False),
     ] = None,
     developer_mode: Annotated[
         Optional[EnableDisableOptionsEnum],
@@ -530,20 +564,38 @@ def update(
         new_ssl_certificate = SSLCertificate(domain=benchname, ssl_type=SUPPORTED_SSL_TYPES.none)
 
         if ssl == SUPPORTED_SSL_TYPES.le:
-            if fm_config_manager.le_email == 'dummy@fm.fm':
-                email = richprint.prompt_ask(prompt='Please enter [bold][green]email[/bold][/green] for Let\'s Encrypt')
-                validate_email(email, check_deliverability=False)
-                fm_config_manager.le_email = email
-                fm_config_manager.export_to_toml()
-                richprint.print(
-                    "Let's Encrypt email saved to configuration. It will be used automatically from now on."
-                )
-            else:
-                richprint.print("Using Let's Encrypt email from configuration.")
-                email = fm_config_manager.le_email
-                fm_config_manager.export_to_toml()
+            if not letsencrypt_preferred_challenge:
+                if fm_config_manager.letsencrypt.exists:
+                    if letsencrypt_preferred_challenge is None:
+                        letsencrypt_preferred_challenge = LETSENCRYPT_PREFERRED_CHALLENGE.dns01
 
-            new_ssl_certificate = LetsencryptSSLCertificate(domain=benchname, ssl_type=ssl, email=email)
+                if not letsencrypt_preferred_challenge:
+                    letsencrypt_preferred_challenge = LETSENCRYPT_PREFERRED_CHALLENGE.http01
+
+            if fm_config_manager.letsencrypt.email == 'dummy@fm.fm' or fm_config_manager.letsencrypt.email is None:
+                if not letsencrypt_email:
+                    richprint.stop()
+                    raise typer.BadParameter(
+                        "No email provided, required by certbot.", param_hint='--letsencrypt-email'
+                    )
+                else:
+                    email = letsencrypt_email
+
+                validate_email(email, check_deliverability=False)
+            else:
+                richprint.print(
+                    "Defaulting to Let's Encrypt email from [blue]fm_config.toml[/blue] since [blue]'--letsencrypt-email'[/blue] is not given."
+                )
+                email = fm_config_manager.letsencrypt.email
+
+            new_ssl_certificate = LetsencryptSSLCertificate(
+                domain=benchname,
+                ssl_type=ssl,
+                email=email,
+                preferred_challenge=letsencrypt_preferred_challenge,
+                api_key=fm_config_manager.letsencrypt.api_key,
+                api_token=fm_config_manager.letsencrypt.api_token,
+            )
 
         richprint.print("Updating Certificate.")
         bench.update_certificate(new_ssl_certificate)

--- a/frappe_manager/metadata_manager.py
+++ b/frappe_manager/metadata_manager.py
@@ -1,21 +1,53 @@
+from typing import Optional
 from pathlib import Path
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 import tomlkit
 from frappe_manager.migration_manager.version import Version
 from frappe_manager import CLI_FM_CONFIG_PATH
+from frappe_manager.ssl_manager import letsencrypt_certificate
 from frappe_manager.utils.helpers import get_current_fm_version
+
+
+class FMLetsencryptConfig(BaseModel):
+    email: Optional[EmailStr] = Field(None, description="Email used by certbot.")
+    api_token: Optional[str] = Field(None, description="Cloudflare API token used by Certbot.")
+    api_key: Optional[str] = Field(None, description="Cloudflare Global API Key used by Certbot.")
+
+    @property
+    def exists(self):
+        if self.api_token or self.api_key:
+            return True
+
+        return False
+
+    def get_toml_doc(self):
+        model_dict = self.model_dump(exclude_none=True)
+        toml_doc = tomlkit.document()
+
+        for key, value in model_dict.items():
+            if isinstance(value, Path):
+                toml_doc[key] = str(value.absolute())
+            else:
+                toml_doc[key] = value
+        return toml_doc
+
+    @classmethod
+    def import_from_toml_doc(cls, toml_doc):
+        print(toml_doc)
+        config_object = cls(**toml_doc)
+        return config_object
 
 
 class FMConfigManager(BaseModel):
     root_path: Path
     version: Version
-    le_email: EmailStr
+    letsencrypt: FMLetsencryptConfig = Field(default=FMLetsencryptConfig())
 
     def export_to_toml(self, path: Path = CLI_FM_CONFIG_PATH) -> bool:
         exclude = {'root_path'}
 
-        if self.le_email == 'dummy@fm.fm':
-            exclude.add('le_email')
+        if self.letsencrypt.email == 'dummy@fm.fm':
+            exclude.add('letsencrypt')
 
         if self.version < Version('0.13.0'):
             path = CLI_FM_CONFIG_PATH.parent / '.fm.toml'
@@ -46,7 +78,7 @@ class FMConfigManager(BaseModel):
         old_config_path = path.parent / '.fm.toml'
 
         input_data['version'] = Version('0.8.3')
-        input_data['le_email'] = 'dummy@fm.fm'
+        input_data['letsencrypt'] = FMLetsencryptConfig(email=None, api_key=None, api_token=None)
         input_data['root_path'] = str(path)
 
         if old_config_path.exists():
@@ -55,7 +87,9 @@ class FMConfigManager(BaseModel):
         elif path.exists():
             data = tomlkit.parse(path.read_text())
             input_data['version'] = Version(data.get('version', get_current_fm_version()))
-            input_data['le_email'] = data.get('le_email', 'dummy@fm.fm')
+            input_data['letsencrypt'] = FMLetsencryptConfig(
+                **data.get('letsencrypt', {'email': None, 'api_key': None, 'api_token': None})
+            )
 
         fm_config_instance = cls(**input_data)
         return fm_config_instance

--- a/frappe_manager/metadata_manager.py
+++ b/frappe_manager/metadata_manager.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel, EmailStr, Field
 import tomlkit
 from frappe_manager.migration_manager.version import Version
 from frappe_manager import CLI_FM_CONFIG_PATH
-from frappe_manager.ssl_manager import letsencrypt_certificate
 from frappe_manager.utils.helpers import get_current_fm_version
 
 
@@ -33,7 +32,6 @@ class FMLetsencryptConfig(BaseModel):
 
     @classmethod
     def import_from_toml_doc(cls, toml_doc):
-        print(toml_doc)
         config_object = cls(**toml_doc)
         return config_object
 
@@ -46,8 +44,11 @@ class FMConfigManager(BaseModel):
     def export_to_toml(self, path: Path = CLI_FM_CONFIG_PATH) -> bool:
         exclude = {'root_path'}
 
-        if self.letsencrypt.email == 'dummy@fm.fm':
+        if not self.letsencrypt.email and not self.letsencrypt.api_key and not self.letsencrypt.api_token:
             exclude.add('letsencrypt')
+        else:
+            if self.letsencrypt.email == 'dummy@fm.fm':
+                exclude.add('letsencrypt')
 
         if self.version < Version('0.13.0'):
             path = CLI_FM_CONFIG_PATH.parent / '.fm.toml'

--- a/frappe_manager/migration_manager/migrations/migrate_0_13_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_13_0.py
@@ -78,6 +78,7 @@ class MigrationV0130(MigrationBase):
         # rename main config
         fm_config_path = CLI_DIR / 'fm_config.toml'
         old_fm_config_path = CLI_DIR / '.fm.toml'
+
         if old_fm_config_path.exists():
             old_fm_config_path.rename(fm_config_path)
 

--- a/frappe_manager/migration_manager/migrations/migrate_0_13_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_13_0.py
@@ -2,6 +2,7 @@ import json
 import os
 import copy
 from pathlib import Path
+import tomlkit
 from frappe_manager.compose_manager import DockerVolumeMount
 from frappe_manager.compose_manager.ComposeFile import ComposeFile
 from frappe_manager.migration_manager.migration_base import MigrationBase
@@ -14,9 +15,6 @@ from frappe_manager.migration_manager.migration_helpers import (
 from frappe_manager.display_manager.DisplayManager import richprint
 from frappe_manager.migration_manager.version import Version
 from frappe_manager import CLI_DIR, CLI_SERVICES_DIRECTORY
-from frappe_manager.site_manager.bench_config import BenchConfig, FMBenchEnvType
-from frappe_manager.ssl_manager import SUPPORTED_SSL_TYPES
-from frappe_manager.ssl_manager.certificate import SSLCertificate
 from frappe_manager.utils.helpers import get_container_name_prefix
 from frappe_manager.docker_wrapper.DockerClient import DockerClient
 from frappe_manager.migration_manager.backup_manager import BackupManager
@@ -133,9 +131,6 @@ class MigrationV0130(MigrationBase):
         # create bench config
         frappe = envs.get('frappe', {})
 
-        userid = frappe.get('USERID', os.getuid())
-        usergroup = frappe.get('USERGROUP', os.getgid())
-
         apps_list = frappe.get('APPS_LIST', None)
 
         if apps_list:
@@ -143,33 +138,18 @@ class MigrationV0130(MigrationBase):
         else:
             apps_list = []
 
-        frappe_branch = frappe.get('FRAPPE_BRANCH', 'version-15')
         developer_mode = frappe.get('DEVELOPER_MODE', True)
-        admin_pass = frappe.get('ADMIN_PASS', 'admin')
         name = frappe.get('SITENAME', bench.name)
-        mariadb_host = frappe.get('MARIADB_HOST', 'global-db')
-        mariadb_root_pass = frappe.get('MARIADB_ROOT_PASS', '/run/secrets/db_root_password')
-        environment_type = frappe.get('ENVIRONMENT', FMBenchEnvType.dev)
-        ssl_certificate = SSLCertificate(domain=bench.name, ssl_type=SUPPORTED_SSL_TYPES.none)
 
-        # TODO Handle admin tools compose change
-        bench_config = BenchConfig(
-            name=name,
-            userid=userid,
-            usergroup=usergroup,
-            apps_list=apps_list,
-            frappe_branch=frappe_branch,
-            developer_mode=developer_mode,
-            admin_tools=True,
-            admin_pass=admin_pass,
-            mariadb_host=mariadb_host,
-            mariadb_root_pass=mariadb_root_pass,
-            environment_type=environment_type,
-            root_path=bench_config_path,
-            ssl=ssl_certificate,
-        )
+        bench_config = tomlkit.document()
 
-        bench_config.export_to_toml(bench_config_path)
+        bench_config['name'] = name
+        bench_config['developer_mode'] = developer_mode
+        bench_config['admin_tools'] = True
+        bench_config['environment_type'] = 'dev'
+
+        with open(bench_config_path, 'w') as f:
+            f.write(tomlkit.dumps(bench_config))
 
         images_info = bench.compose_project.compose_file_manager.get_all_images()
 

--- a/frappe_manager/migration_manager/migrations/migrate_0_14_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_14_0.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import tomlkit
+from frappe_manager.migration_manager.migration_base import MigrationBase
+from frappe_manager.migration_manager.migration_helpers import MigrationBenches, MigrationServicesManager
+from frappe_manager.migration_manager.version import Version
+from frappe_manager.migration_manager.backup_manager import BackupManager
+
+
+class MigrationV0140(MigrationBase):
+    version = Version("0.14.0")
+
+    def init(self):
+        self.cli_dir: Path = Path.home() / 'frappe'
+        self.benches_dir = self.cli_dir / "sites"
+        self.backup_manager = BackupManager(str(self.version), self.benches_dir)
+        self.benches_manager = MigrationBenches(self.benches_dir)
+        self.services_manager: MigrationServicesManager = MigrationServicesManager(
+            services_path=self.cli_dir / 'services'
+        )
+
+    def migrate_services(self):
+        config_path = self.cli_dir / 'fm_config.toml'
+
+        if config_path.exists():
+            data = tomlkit.parse(config_path.read_text())
+            email = data.get('le_email', None)
+            data['letsencrypt'] = {'email': email}
+
+            if email:
+                del data['le_email']
+
+            with open(config_path, 'w') as f:
+                f.write(tomlkit.dumps(data))

--- a/frappe_manager/migration_manager/migrations/migrate_0_14_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_14_0.py
@@ -4,6 +4,7 @@ from frappe_manager.migration_manager.migration_base import MigrationBase
 from frappe_manager.migration_manager.migration_helpers import MigrationBenches, MigrationServicesManager
 from frappe_manager.migration_manager.version import Version
 from frappe_manager.migration_manager.backup_manager import BackupManager
+from frappe_manager.display_manager.DisplayManager import richprint
 
 
 class MigrationV0140(MigrationBase):
@@ -19,15 +20,17 @@ class MigrationV0140(MigrationBase):
         )
 
     def migrate_services(self):
+        richprint.change_head("Migrating [blue]fm_config.toml[/blue] changes")
         config_path = self.cli_dir / 'fm_config.toml'
 
         if config_path.exists():
             data = tomlkit.parse(config_path.read_text())
             email = data.get('le_email', None)
-            data['letsencrypt'] = {'email': email}
 
             if email:
+                data['letsencrypt'] = {'email': email}
                 del data['le_email']
 
             with open(config_path, 'w') as f:
                 f.write(tomlkit.dumps(data))
+        richprint.print("Migrated [blue]fm_config.toml[/blue]")

--- a/frappe_manager/ssl_manager/__init__.py
+++ b/frappe_manager/ssl_manager/__init__.py
@@ -4,3 +4,8 @@ from enum import Enum
 class SUPPORTED_SSL_TYPES(str, Enum):
     le = 'letsencrypt'
     none = 'disable'
+
+
+class LETSENCRYPT_PREFERRED_CHALLENGE(str, Enum):
+    dns01 = 'dns01'
+    http01 = 'http01'

--- a/frappe_manager/ssl_manager/certificate.py
+++ b/frappe_manager/ssl_manager/certificate.py
@@ -14,16 +14,3 @@ class SSLCertificate(BaseModel):
     @property
     def has_wildcard(self) -> bool:
         return any(is_wildcard_fqdn(domain) for domain in self.alias_domains)
-
-
-class LetsencryptSSLCertificate(BaseModel):
-    domain: str
-    email: str
-    ssl_type: SUPPORTED_SSL_TYPES
-    hsts: str = 'off'
-    alias_domains: List[str] = []
-    toml_exclude: Optional[set] = {'domain', 'alias_domains', 'toml_exclude'}
-
-    @property
-    def has_wildcard(self) -> bool:
-        return any(is_wildcard_fqdn(domain) for domain in self.alias_domains)

--- a/frappe_manager/ssl_manager/certificate_exceptions.py
+++ b/frappe_manager/ssl_manager/certificate_exceptions.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from frappe_manager import CLI_FM_CONFIG_PATH
 
 from frappe_manager.utils.helpers import format_ssl_certificate_time_remaining
 
@@ -13,11 +13,21 @@ class SSLCertificateNotFoundError(Exception):
         super().__init__(self.message)
 
 
-class SSLDNSChallengeNotImplemented(Exception):
-    """Exception raised for dns method not implemented."""
+class SSLCertificateEmailNotFoundError(Exception):
+    """Exception raised when a certificate is not found."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, domain, message="Please provide email using flag '"):
+        self.domain = domain
+        self.message = message.format(self.domain)
+        super().__init__(self.message)
+
+
+class SSLDNSChallengeCredentailsNotFound(Exception):
+    """Exception raised for dns method required credential not found."""
+
+    def __init__(self, message: str = f"Cloudflare dns credentials not found in {CLI_FM_CONFIG_PATH}"):
+        self.message = message
+        super().__init__(message)
 
 
 class SSLCertificateChallengeFailed(Exception):

--- a/frappe_manager/ssl_manager/letsencrypt_certificate.py
+++ b/frappe_manager/ssl_manager/letsencrypt_certificate.py
@@ -1,5 +1,41 @@
-from pydantic import EmailStr
+from typing import Optional, List, Self
+from pydantic import EmailStr, Field, model_validator, validator
+from frappe_manager.ssl_manager import LETSENCRYPT_PREFERRED_CHALLENGE
 from frappe_manager.ssl_manager.certificate import SSLCertificate
+from frappe_manager.ssl_manager.certificate_exceptions import SSLDNSChallengeCredentailsNotFound
+from frappe_manager.display_manager.DisplayManager import richprint
+
 
 class LetsencryptSSLCertificate(SSLCertificate):
-    email: EmailStr
+    preferred_challenge: LETSENCRYPT_PREFERRED_CHALLENGE
+    email: EmailStr = Field(..., description="Email used by certbot.")
+    api_token: Optional[str] = Field(None, description="Cloudflare API token used by Certbot.")
+    api_key: Optional[str] = Field(None, description="Cloudflare Global API Key used by Certbot.")
+    toml_exclude: Optional[set] = {'domain', 'alias_domains', 'toml_exclude', 'api_token', 'api_key'}
+
+    @model_validator(mode="after")
+    def validate_credentials(self) -> Self:
+        if self.preferred_challenge == LETSENCRYPT_PREFERRED_CHALLENGE.dns01:
+            if self.api_key or self.api_token:
+                return self
+            else:
+                raise SSLDNSChallengeCredentailsNotFound()
+
+        return self
+
+    def get_cloudflare_dns_credentials(self) -> str:
+        creds: List[str] = []
+
+        if self.api_key:
+            richprint.print('Using Cloudflare GLOBAL API KEY')
+            creds.append(f'dns_cloudflare_email = {self.email}\n')
+            creds.append(f'dns_cloudflare_api_key = {self.api_key}\n')
+
+        if self.api_token:
+            richprint.print('Using Cloudflare API Token')
+            creds.append(f'dns_cloudflare_api_token = {self.api_token}\n')
+
+        if not creds:
+            raise SSLDNSChallengeCredentailsNotFound()
+
+        return "\n".join(creds)

--- a/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
+++ b/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
@@ -99,7 +99,6 @@ class LetsEncryptCertificateService(SSLCertificateService):
             gen_command += f' --dns-cloudflare --dns-cloudflare-credentials {temp_file.name}'
 
         gen_command += f' --keep-until-expiring --expand'
-        gen_command += ' --staging'
         gen_command += f' --agree-tos -m "{certificate.email}" --no-eff-email'
 
         all_domains = [f'{certificate.domain}'] + certificate.alias_domains

--- a/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
+++ b/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
@@ -1,7 +1,7 @@
 import shlex
 from io import StringIO
 from pathlib import Path
-from typing import List, Literal, Tuple
+from typing import List, Tuple
 from certbot._internal.main import make_or_verify_needed_dirs
 from certbot._internal.plugins import disco as plugins_disco
 from certbot._internal import cli, storage
@@ -9,7 +9,7 @@ from certbot._internal.display import obj as display_obj
 from certbot import crypto_util
 from certbot.errors import AuthorizationError
 from frappe_manager.logger import log
-from frappe_manager.ssl_manager import SUPPORTED_SSL_TYPES
+from frappe_manager.ssl_manager import LETSENCRYPT_PREFERRED_CHALLENGE, SUPPORTED_SSL_TYPES
 from frappe_manager.ssl_manager.certificate_exceptions import (
     SSLCertificateChallengeFailed,
     SSLCertificateGenerateFailed,
@@ -25,10 +25,8 @@ class LetsEncryptCertificateService(SSLCertificateService):
         self,
         ssl_service_dir: Path,
         webroot_dir: Path,
-        preferred_challenge: Literal['http', 'dns'] = 'http',
     ):
         self.webroot_dir = webroot_dir
-        self.preferred_challenge = preferred_challenge
         self.root_dir = ssl_service_dir / SUPPORTED_SSL_TYPES.le.value
 
         # certbot dirs
@@ -37,6 +35,7 @@ class LetsEncryptCertificateService(SSLCertificateService):
         self.logs_dir: Path = self.root_dir / 'logs'
 
         self.base_command = f"--work-dir {self.work_dir} --config-dir {self.config_dir} --logs-dir {self.logs_dir}"
+        self.logger = log.get_logger()
         self.console_output = StringIO()
 
     def renew_certificate(self, certificate: LetsencryptSSLCertificate):
@@ -81,9 +80,26 @@ class LetsEncryptCertificateService(SSLCertificateService):
         richprint.print("Removed Letsencrypt certificate")
 
     def generate_certificate(self, certificate: LetsencryptSSLCertificate):
-        gen_command: str = self.base_command + f" certonly --webroot -w {self.webroot_dir} "
+        gen_command: str = self.base_command + f" certonly "
+
+        richprint.print(f"Using Let's Encrypt {certificate.preferred_challenge.value} challenge.")
+
+        import tempfile
+
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+
+        if certificate.preferred_challenge == LETSENCRYPT_PREFERRED_CHALLENGE.http01:
+            gen_command += f' --webroot -w {self.webroot_dir}'
+
+        elif certificate.preferred_challenge == LETSENCRYPT_PREFERRED_CHALLENGE.dns01:
+            api_creds = certificate.get_cloudflare_dns_credentials()
+            temp_file.write(api_creds.encode())
+            temp_file.flush()
+
+            gen_command += f' --dns-cloudflare --dns-cloudflare-credentials {temp_file.name}'
+
         gen_command += f' --keep-until-expiring --expand'
-        # gen_command += ' --staging'
+        gen_command += ' --staging'
         gen_command += f' --agree-tos -m "{certificate.email}" --no-eff-email'
 
         all_domains = [f'{certificate.domain}'] + certificate.alias_domains
@@ -94,22 +110,27 @@ class LetsEncryptCertificateService(SSLCertificateService):
 
         try:
             richprint.change_head("Getting Letsencrypt certificate")
+            self.logger.debug(f'Certbot command: {gen_command}')
             config = self._get_le_config(shlex.split(gen_command), quiet=True)
             plugins = plugins_disco.PluginsRegistry.find_all()
             config.func(config, plugins)
-            richprint.stdout.print(self.console_output.getvalue().strip())
+            output = '\n'.join(line for line in self.console_output.getvalue().split('\n') if not line.startswith('!!'))
+            richprint.stdout.print(output)
 
         except AuthorizationError as e:
-            logger = log.get_logger()
-            logger.exception(e)
-            richprint.stdout.print(self.console_output.getvalue().strip())
-            raise SSLCertificateChallengeFailed(self.preferred_challenge)
+            self.logger.exception(e)
+            output = '\n'.join(line for line in self.console_output.getvalue().split('\n') if not line.startswith('!!'))
+            richprint.stdout.print(output)
+            raise SSLCertificateChallengeFailed(certificate.preferred_challenge)
 
         except Exception as e:
-            logger = log.get_logger()
-            logger.exception(e)
-            richprint.stdout.print(self.console_output.getvalue().strip())
+            self.logger.exception(e)
+            output = '\n'.join(line for line in self.console_output.getvalue().split('\n') if not line.startswith('!!'))
+            richprint.stdout.print(output)
             raise SSLCertificateGenerateFailed()
+
+        finally:
+            temp_file.close()
 
         richprint.print("Acquired Letsencrypt certificate: Done")
         return self.get_certificate_paths(certificate)

--- a/frappe_manager/ssl_manager/ssl_certificate_manager.py
+++ b/frappe_manager/ssl_manager/ssl_certificate_manager.py
@@ -7,7 +7,6 @@ from frappe_manager.ssl_manager.no_op_certificate_service import NoOpCertificate
 from frappe_manager.ssl_manager.certificate_exceptions import (
     SSLCertificateNotDueForRenewalError,
     SSLCertificateNotFoundError,
-    SSLDNSChallengeNotImplemented,
 )
 from frappe_manager.ssl_manager.certificate import SSLCertificate
 from frappe_manager.ssl_manager.nginxproxymanager import NginxProxyManager
@@ -23,10 +22,6 @@ class SSLCertificateManager:
     proxy_manager: NginxProxyManager
 
     def __init__(self, certificate: SSLCertificate, webroot_dir: Path, proxy_manager: NginxProxyManager):
-        # Check if the domains and alias domains doesn't contain wildcards
-        if certificate.has_wildcard:
-            raise SSLDNSChallengeNotImplemented
-
         self.certificate = certificate
         self.proxy_manager = proxy_manager
         self.webroot_dir = webroot_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "frappe-manager"
-version = "0.13.4"
+version = "0.14.0"
 license = "MIT"
 repository = "https://github.com/rtcamp/frappe-manager"
 description = "A CLI tool based on Docker Compose to easily manage Frappe based projects. As of now, only suitable for development in local machines running on Mac and Linux based OS."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ certbot = "^2.9.0"
 pydantic = "^2.6.4"
 email-validator = "^2.1.1"
 jinja2 = "^3.1.3"
+certbot-dns-cloudflare = "^2.10.0"
 
 [tool.pyright]
 reportOptionalMemberAccess = false


### PR DESCRIPTION
- This PR provides Cloudflare DNS Challenge support for ssl certficate creation.
- Cloudflare dns support is provided using certbot plugin `certbot-dns-cloudflare`. This plugin handles the automatic creation of TXT records for us.
- FM exposes expose `[letsencrypt]` section in fm_config.toml file which contains `api_token`,`api_key` and `email`.
- Handle error when DNS challenge is used and Cloudflare credentials is not provided.
