### PR TITLE
Add bench specific cloudflare certbot config

### DIFF
--- a/frappe_manager/site_manager/bench_config.py
+++ b/frappe_manager/site_manager/bench_config.py
@@ -106,17 +106,28 @@ class BenchConfig(BaseModel):
 
         data['root_path'] = str(path)
 
-        # Extract SSL data and remove it from the main data dictionary
         ssl_data = data.get('ssl', None)
+
         if ssl_data:
             domain: str = data.get('name', None)  # Set domain from main data if necessary
             ssl_type = ssl_data.get('ssl_type', SUPPORTED_SSL_TYPES.none)
+
             if ssl_type == SUPPORTED_SSL_TYPES.le:
                 email = ssl_data.get('email', None)
 
                 fm_config_manager = FMConfigManager.import_from_toml()
 
-                pref_challenge_data = data.get("preferred_challenge", None)
+                pref_challenge_data = ssl_data.get("preferred_challenge", None)
+
+                api_token = ssl_data.get('api_token', None)
+
+                if not api_token:
+                    api_token = fm_config_manager.letsencrypt.api_token
+
+                api_key = ssl_data.get('api_key', None)
+
+                if not api_key:
+                    api_key = fm_config_manager.letsencrypt.api_key
 
                 if not pref_challenge_data:
                     if fm_config_manager.letsencrypt.exists:
@@ -131,8 +142,8 @@ class BenchConfig(BaseModel):
                     ssl_type=ssl_type,
                     email=email,
                     preferred_challenge=preferred_challenge,
-                    api_key=fm_config_manager.letsencrypt.api_key,
-                    api_token=fm_config_manager.letsencrypt.api_token,
+                    api_key=api_key,
+                    api_token=api_token,
                 )
             else:
                 ssl_instance = SSLCertificate(domain=domain, ssl_type=SUPPORTED_SSL_TYPES.none)

--- a/frappe_manager/ssl_manager/letsencrypt_certificate.py
+++ b/frappe_manager/ssl_manager/letsencrypt_certificate.py
@@ -11,7 +11,7 @@ class LetsencryptSSLCertificate(SSLCertificate):
     email: EmailStr = Field(..., description="Email used by certbot.")
     api_token: Optional[str] = Field(None, description="Cloudflare API token used by Certbot.")
     api_key: Optional[str] = Field(None, description="Cloudflare Global API Key used by Certbot.")
-    toml_exclude: Optional[set] = {'domain', 'alias_domains', 'toml_exclude', 'api_token', 'api_key'}
+    toml_exclude: Optional[set] = {'domain', 'alias_domains', 'toml_exclude'}
 
     @model_validator(mode="after")
     def validate_credentials(self) -> Self:

--- a/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
+++ b/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
@@ -95,6 +95,7 @@ class LetsEncryptCertificateService(SSLCertificateService):
 
             api_creds = certificate.get_cloudflare_dns_credentials()
             dns_config_path.write_text(api_creds)
+            dns_config_path.chmod(0o600)
 
             gen_command += f' --dns-cloudflare --dns-cloudflare-credentials {dns_config_path.absolute()}'
 

--- a/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
+++ b/frappe_manager/ssl_manager/letsencrypt_certificate_service.py
@@ -33,6 +33,7 @@ class LetsEncryptCertificateService(SSLCertificateService):
         self.config_dir: Path = self.root_dir / "config"
         self.work_dir: Path = self.root_dir / 'work'
         self.logs_dir: Path = self.root_dir / 'logs'
+        self.dns_config_dir = self.root_dir / 'dns_configs'
 
         self.base_command = f"--work-dir {self.work_dir} --config-dir {self.config_dir} --logs-dir {self.logs_dir}"
         self.logger = log.get_logger()
@@ -84,19 +85,18 @@ class LetsEncryptCertificateService(SSLCertificateService):
 
         richprint.print(f"Using Let's Encrypt {certificate.preferred_challenge.value} challenge.")
 
-        import tempfile
-
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        dns_config_path = self.dns_config_dir / f'{certificate.domain}.txt'
 
         if certificate.preferred_challenge == LETSENCRYPT_PREFERRED_CHALLENGE.http01:
             gen_command += f' --webroot -w {self.webroot_dir}'
 
         elif certificate.preferred_challenge == LETSENCRYPT_PREFERRED_CHALLENGE.dns01:
-            api_creds = certificate.get_cloudflare_dns_credentials()
-            temp_file.write(api_creds.encode())
-            temp_file.flush()
+            self.dns_config_dir.mkdir(parents=True, exist_ok=True)
 
-            gen_command += f' --dns-cloudflare --dns-cloudflare-credentials {temp_file.name}'
+            api_creds = certificate.get_cloudflare_dns_credentials()
+            dns_config_path.write_text(api_creds)
+
+            gen_command += f' --dns-cloudflare --dns-cloudflare-credentials {dns_config_path.absolute()}'
 
         gen_command += f' --keep-until-expiring --expand'
         gen_command += f' --agree-tos -m "{certificate.email}" --no-eff-email'
@@ -120,16 +120,15 @@ class LetsEncryptCertificateService(SSLCertificateService):
             self.logger.exception(e)
             output = '\n'.join(line for line in self.console_output.getvalue().split('\n') if not line.startswith('!!'))
             richprint.stdout.print(output)
+            dns_config_path.unlink()
             raise SSLCertificateChallengeFailed(certificate.preferred_challenge)
 
         except Exception as e:
             self.logger.exception(e)
             output = '\n'.join(line for line in self.console_output.getvalue().split('\n') if not line.startswith('!!'))
             richprint.stdout.print(output)
+            dns_config_path.unlink()
             raise SSLCertificateGenerateFailed()
-
-        finally:
-            temp_file.close()
 
         richprint.print("Acquired Letsencrypt certificate: Done")
         return self.get_certificate_paths(certificate)

--- a/frappe_manager/templates/bench_config.toml
+++ b/frappe_manager/templates/bench_config.toml
@@ -1,20 +1,34 @@
-name = "example.com"
+# Denotes the bench name.
+# Should not be edited by user.
+name = "fm.com"
 
-# when true enables frappe developer mode
+# Enables Frappe developer mode for the bench.
 developer_mode = false
 
-# when true enables admin tools mode
+# Enables admin tools (e.g., Mailhog and Adminer) for the bench.
 admin_tools = false
 
-# "prod" -> for bench prod environment
-# "dev"  -> for bench dev environment
+# Sets the bench environment to either "prod" (production) or "dev" (development).
 environment_type = "prod"
 
-# enable ssl if defined
 [ssl]
-# ssl_type -> "letsencrypt" / "disable"
+# Sets the SSL type to be used by the bench, in this case, "letsencrypt" for Let's Encrypt.
 ssl_type = "letsencrypt"
-# only applicable if ssl_type is "letsencrypt"
+
+# Controls the HSTS (HTTP Strict Transport Security) header used by the bench.
+# When set to "off", the HSTS header will not be included.
 hsts = "off"
-# only applicable if ssl_type is "letsencrypt"
-email = "exampl@example.com"
+
+# Specifies the preferred Certbot challenge method to be used for Let's Encrypt certificate validation.
+preferred_challenge = "http01"
+
+# The email address associated with Let's Encrypt.
+# This is used for notifications, recovery, and is used with `api_key` for the Global API key of Cloudflare.
+# For more information, see [this documentation](https://certbot-dns-cloudflare.readthedocs.io/en/stable/#certbot-cloudflare-key-ini).
+email = "cloudflare@example.com"
+
+# Cloudflare Global API Key for Let's Encrypt DNS01 Challenge.
+api_token = "0123456789abcdef0123456789abcdef01234567"
+
+# Cloudflare API token for Let's Encrypt DNS01 Challenge.
+api_key = "0123456789abcdef0123456789abcdef01234"

--- a/frappe_manager/templates/fm_config.toml
+++ b/frappe_manager/templates/fm_config.toml
@@ -1,5 +1,15 @@
-# Don't change the version no this will affect the migrations.
-version = "0.13.0" # set by fm to the current version
+# Denotes the current version of fm.
+# Should not be edited by user.
+version = "0.14.0"
 
-# Email used by Let's Encrypt if set then fm will never ask email for Let's Encrypt.
-le_email = 'example@example.com'
+[letsencrypt]
+# The email address associated with Let's Encrypt.
+# This is used for notifications, recovery, and is used with api_key for the Global API key of Cloudflare.
+# For more information, see [this documentation](https://certbot-dns-cloudflare.readthedocs.io/en/stable/#certbot-cloudflare-key-ini).
+email = 'cloudflare@example.co'
+
+# Cloudflare API token for Let's Encrypt DNS01 Challenge.
+api_key = '0123456789abcdef0123456789abcdef01234'
+
+# Cloudflare Global API Key for Let's Encrypt DNS01 Challenge.
+api_token = '0123456789abcdef0123456789abcdef01234567'

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,6 +36,25 @@ files = [
 ]
 
 [[package]]
+name = "attrs"
+version = "23.2.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
+    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
+]
+
+[package.extras]
+cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
+dev = ["attrs[tests]", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs[tests-no-zope]", "zope-interface"]
+tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
+tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
+
+[[package]]
 name = "certbot"
 version = "2.10.0"
 description = "ACME client"
@@ -64,6 +83,27 @@ all = ["Sphinx (>=1.2)", "azure-devops", "coverage", "ipdb", "mypy", "pip", "poe
 dev = ["azure-devops", "ipdb", "poetry (>=1.2.0)", "poetry-plugin-export (>=1.1.0)", "twine"]
 docs = ["Sphinx (>=1.2)", "sphinx-rtd-theme"]
 test = ["coverage", "mypy", "pip", "pylint", "pytest", "pytest-cov", "pytest-xdist", "setuptools", "tox", "types-httplib2", "types-pyOpenSSL", "types-pyRFC3339", "types-pytz", "types-pywin32", "types-requests", "types-setuptools", "types-six", "wheel"]
+
+[[package]]
+name = "certbot-dns-cloudflare"
+version = "2.10.0"
+description = "Cloudflare DNS Authenticator plugin for Certbot"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "certbot-dns-cloudflare-2.10.0.tar.gz", hash = "sha256:45b058c3e515a1853b33dcc3367c12978c0930990a563d26c879d9883a639c07"},
+    {file = "certbot_dns_cloudflare-2.10.0-py3-none-any.whl", hash = "sha256:2b26ed46a1c0f152478b7372f1fc36a4fa1612aa05cde3ab21dada724b32ed40"},
+]
+
+[package.dependencies]
+acme = ">=2.10.0"
+certbot = ">=2.10.0"
+cloudflare = ">=1.5.1"
+setuptools = ">=41.6.0"
+
+[package.extras]
+docs = ["Sphinx (>=1.0)", "sphinx-rtd-theme"]
+test = ["pytest"]
 
 [[package]]
 name = "certifi"
@@ -254,6 +294,24 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "cloudflare"
+version = "2.20.0"
+description = "Python wrapper for the Cloudflare v4 API"
+optional = false
+python-versions = ">3.6.0"
+files = [
+    {file = "cloudflare-2.20.0.tar.gz", hash = "sha256:46aefc39dfaa2365d639b423cec2cd5350ae11153c7247d3eb3545bdcf01a68a"},
+]
+
+[package.dependencies]
+jsonlines = "*"
+pyyaml = "*"
+requests = "*"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -438,6 +496,20 @@ pyopenssl = ">=0.13"
 
 [package.extras]
 docs = ["sphinx (>=4.3.0)", "sphinx-rtd-theme (>=1.0)"]
+
+[[package]]
+name = "jsonlines"
+version = "4.0.0"
+description = "Library with helpers for the jsonlines file format"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jsonlines-4.0.0-py3-none-any.whl", hash = "sha256:185b334ff2ca5a91362993f42e83588a360cf95ce4b71a73548502bda52a7c55"},
+    {file = "jsonlines-4.0.0.tar.gz", hash = "sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
 
 [[package]]
 name = "markdown-it-py"
@@ -785,6 +857,66 @@ files = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -1004,4 +1136,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "bb03f1df584decf16ac142f49cfd6378a799bbf3638fbef570198c9020e16a88"
+content-hash = "30700255d7d524fddd9d91dba0b9559e3f356ea14ab2d37abcceb4c27156e4a8"


### PR DESCRIPTION
This PR:
- Add per bench certbot DNS cloudflare config support using `bench_config.toml`. #15
- Show Letsencrypt challenge info in `info` command.