### PR TITLE
Add examples for all commands

### DIFF
--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -1,26 +1,49 @@
 from pathlib import Path
 from enum import Enum
-import rich
+from typing import Optional
 from typer.core import TyperCommand
 from frappe_manager.utils.cli_examples import get_examples_from_toml
 import typer.rich_utils as ut
 from rich.panel import Panel
 
 # patch rich_format_help to display examples Panel
+# save the function so that recurssion doesn't occur
 rich_format_help_original = ut.rich_format_help
-def print_fm_examples(*,obj, ctx, markup_mode):
-    rich_format_help_original(obj=obj,ctx=ctx,markup_mode=markup_mode)
-    new_doc = get_examples_from_toml(obj.name, frappe_version=STABLE_APP_BRANCH_MAPPING_LIST['frappe'])
-    from rich import inspect
-    inspect(obj)
-    if isinstance(obj,TyperCommand):
-        rich.print(Panel(
-            new_doc,
-            padding=ut.STYLE_OPTIONS_TABLE_PADDING,
-            border_style=ut.STYLE_OPTIONS_PANEL_BORDER,
-            title='Examples',
-            title_align=ut.ALIGN_OPTIONS_PANEL,
-    ))
+
+
+def print_fm_examples(*, obj, ctx, markup_mode):
+    # utilising the original saved function
+    rich_format_help_original(obj=obj, ctx=ctx, markup_mode=markup_mode)
+
+    print(ctx.command_path.split(' '))
+    if not hasattr(ctx.parent, 'info_name'):
+        return
+
+    command = ctx.parent.info_name
+
+    sub_command: Optional[str] = None
+
+    if command == 'fm':
+        command = ctx.info_name
+    else:
+        sub_command = ctx.info_name
+
+
+    new_doc = get_examples_from_toml(command=command, frappe_version=STABLE_APP_BRANCH_MAPPING_LIST["frappe"], sub_command=sub_command)
+
+    if new_doc:
+        if isinstance(obj, TyperCommand):
+            # printing the examples at the end of the help
+            import rich
+            rich.print(
+                Panel(
+                    new_doc,
+                    padding=ut.STYLE_OPTIONS_TABLE_PADDING,
+                    border_style=ut.STYLE_OPTIONS_PANEL_BORDER,
+                    title="Examples",
+                    title_align=ut.ALIGN_OPTIONS_PANEL,
+                )
+            )
 
 ut.rich_format_help = print_fm_examples
 
@@ -29,14 +52,14 @@ ut.rich_format_help = print_fm_examples
 CLI_DIR = Path.home() / "frappe"
 CLI_FM_CONFIG_PATH = CLI_DIR / "fm_config.toml"
 CLI_SITES_ARCHIVE = CLI_DIR / "archived"
-CLI_LOG_DIRECTORY = CLI_DIR / 'logs'
-CLI_BENCHES_DIRECTORY = CLI_DIR / 'sites'
-CLI_SERVICES_DIRECTORY = CLI_DIR / 'services'
+CLI_LOG_DIRECTORY = CLI_DIR / "logs"
+CLI_BENCHES_DIRECTORY = CLI_DIR / "sites"
+CLI_SERVICES_DIRECTORY = CLI_DIR / "services"
 
-CLI_SERVICES_NGINX_PROXY_DIR = CLI_SERVICES_DIRECTORY / 'nginx-proxy'
-CLI_SERVICES_NGINX_PROXY_SSL_DIR = CLI_SERVICES_NGINX_PROXY_DIR / 'ssl'
+CLI_SERVICES_NGINX_PROXY_DIR = CLI_SERVICES_DIRECTORY / "nginx-proxy"
+CLI_SERVICES_NGINX_PROXY_SSL_DIR = CLI_SERVICES_NGINX_PROXY_DIR / "ssl"
 
-CLI_BENCH_CONFIG_FILE_NAME = 'bench_config.toml'
+CLI_BENCH_CONFIG_FILE_NAME = "bench_config.toml"
 SSL_RENEW_BEFORE_DAYS = 30
 
 
@@ -64,12 +87,12 @@ class SiteServicesEnum(str, Enum):
 
 
 STABLE_APP_BRANCH_MAPPING_LIST = {
-    "frappe": 'version-15',
-    "erpnext": 'version-15',
-    "hrms": 'version-15',
+    "frappe": "version-15",
+    "erpnext": "version-15",
+    "hrms": "version-15",
 }
 
 
 class EnableDisableOptionsEnum(str, Enum):
-    enable = 'enable'
-    disable = 'disable'
+    enable = "enable"
+    disable = "disable"

--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -15,35 +15,21 @@ def print_fm_examples(*, obj, ctx, markup_mode):
     # utilising the original saved function
     rich_format_help_original(obj=obj, ctx=ctx, markup_mode=markup_mode)
 
-    print(ctx.command_path.split(' '))
-    if not hasattr(ctx.parent, 'info_name'):
-        return
+    commands_stack = ctx.command_path.split(' ')[1:]
 
-    command = ctx.parent.info_name
-
-    sub_command: Optional[str] = None
-
-    if command == 'fm':
-        command = ctx.info_name
-    else:
-        sub_command = ctx.info_name
-
-
-    new_doc = get_examples_from_toml(command=command, frappe_version=STABLE_APP_BRANCH_MAPPING_LIST["frappe"], sub_command=sub_command)
+    new_doc = get_examples_from_toml(commands_stack=commands_stack, frappe_version=STABLE_APP_BRANCH_MAPPING_LIST["frappe"])
 
     if new_doc:
-        if isinstance(obj, TyperCommand):
-            # printing the examples at the end of the help
-            import rich
-            rich.print(
-                Panel(
-                    new_doc,
-                    padding=ut.STYLE_OPTIONS_TABLE_PADDING,
-                    border_style=ut.STYLE_OPTIONS_PANEL_BORDER,
-                    title="Examples",
-                    title_align=ut.ALIGN_OPTIONS_PANEL,
-                )
+        import rich
+        rich.print(
+            Panel(
+                new_doc,
+                padding=ut.STYLE_OPTIONS_TABLE_PADDING,
+                border_style=ut.STYLE_OPTIONS_PANEL_BORDER,
+                title="Examples",
+                title_align=ut.ALIGN_OPTIONS_PANEL,
             )
+        )
 
 ut.rich_format_help = print_fm_examples
 

--- a/frappe_manager/__init__.py
+++ b/frappe_manager/__init__.py
@@ -1,5 +1,28 @@
 from pathlib import Path
 from enum import Enum
+import rich
+from typer.core import TyperCommand
+from frappe_manager.utils.cli_examples import get_examples_from_toml
+import typer.rich_utils as ut
+from rich.panel import Panel
+
+# patch rich_format_help to display examples Panel
+rich_format_help_original = ut.rich_format_help
+def print_fm_examples(*,obj, ctx, markup_mode):
+    rich_format_help_original(obj=obj,ctx=ctx,markup_mode=markup_mode)
+    new_doc = get_examples_from_toml(obj.name, frappe_version=STABLE_APP_BRANCH_MAPPING_LIST['frappe'])
+    from rich import inspect
+    inspect(obj)
+    if isinstance(obj,TyperCommand):
+        rich.print(Panel(
+            new_doc,
+            padding=ut.STYLE_OPTIONS_TABLE_PADDING,
+            border_style=ut.STYLE_OPTIONS_PANEL_BORDER,
+            title='Examples',
+            title_align=ut.ALIGN_OPTIONS_PANEL,
+    ))
+
+ut.rich_format_help = print_fm_examples
 
 # TODO configure this using config
 # sites_dir = Path().home() / __name__.split(".")[0]

--- a/frappe_manager/commands.py
+++ b/frappe_manager/commands.py
@@ -141,7 +141,6 @@ def app_callback(
         ctx.obj["verbose"] = verbose
         ctx.obj['fm_config_manager'] = fm_config_manager
 
-
 @app.command(no_args_is_help=True)
 def create(
     ctx: typer.Context,
@@ -187,22 +186,6 @@ def create(
     # TODO Create markdown table for the below help
     """
     Create a new bench.
-
-    Frappe\[version-15] will be installed by default.
-
-    [bold white on black]Examples:[/bold white on black]
-
-    [bold]# Install frappe\[version-15][/bold]
-    $ [blue]fm create example[/blue]
-
-    [bold]# Install frappe\[develop][/bold]
-    $ [blue]fm create example --frappe-branch develop[/blue]
-
-    [bold]# Install frappe\[version-15], erpnext\[version-15] and hrms\[version-15][/bold]
-    $ [blue]fm create example --apps erpnext:version-15 --apps hrms:version-15[/blue]
-
-    [bold]# Install frappe\[version-15], erpnext\[version-14] and hrms\[version-14][/bold]
-    $ [blue]fm create example --frappe-branch version-14 --apps erpnext:version-14 --apps hrms:version-14[/blue]
     """
 
     services_manager: ServicesManager = ctx.obj["services"]

--- a/frappe_manager/utils/cli_examples.py
+++ b/frappe_manager/utils/cli_examples.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, List, Optional
+from typing import Dict, List
 import json
 from pathlib import Path
 import importlib.resources as pkg_resources
@@ -7,50 +7,48 @@ import importlib.resources as pkg_resources
 def get_frappe_manager_own_files(file_path: str):
     return Path(str(pkg_resources.files("frappe_manager").joinpath(file_path)))
 
-def get_examples_from_toml(command: str, frappe_version: str, toml_path: Path = get_frappe_manager_own_files('./utils/examples.json'), sub_command: Optional[str] = None ):
+def get_examples_from_toml(commands_stack: List[str], frappe_version: str, toml_path: Path = get_frappe_manager_own_files('./utils/examples.json')):
     file_data = toml_path.read_bytes()
     data: Dict[str,List[Dict[str,str]]] = json.loads(file_data)
 
     bench_name = 'example.com'
 
     example_data ={
-        'command' : command,
-        'sub_command' : sub_command,
         'benchname' : bench_name,
         'default_version' : frappe_version
     }
+
+    examples_data = deepcopy(data)
+
+    for command in commands_stack:
+        if not command in examples_data:
+            return None
+
+        examples_data = examples_data[command]
+
+
+    if not 'examples' in examples_data:
+        return None
+
+    examples_data = examples_data['examples']
 
     from rich.table import Table
 
     examples_table = Table(padding=(0,0),title=None,show_header=False,show_lines=False, box=None)
 
-    if command in data:
-        examples_data = data[command]
+    if examples_data:
+        element_example_data = deepcopy(example_data)
 
-        if isinstance(examples_data, dict):
-            if not sub_command:
-                if not 'examples'in examples_data:
-                    return None
-            else:
-                examples_data = examples_data[sub_command]
-                sub_command = f" {sub_command} "
-        else:
-            sub_command = ' '
+        for element in examples_data:
+            desc = element.get('desc', 'None')
+            code = element.get('code', 'None')
 
+            if 'benchname' in element:
+                element_example_data['benchname'] = element['benchname']
 
-        if examples_data:
-            element_example_data = deepcopy(example_data)
+            element_table = Table(box=None,show_lines=False)
 
-            for element in examples_data:
-                desc = element.get('desc', 'None')
-                code = element.get('code', 'None')
-
-                if 'benchname' in element:
-                    element_example_data['benchname'] = element['benchname']
-
-                element_table = Table(box=None,show_lines=False)
-
-                element_table.add_row(f"[bold cyan]{desc.format(**example_data)}[/bold cyan]")
-                element_table.add_row(f"[blue]:play_button:[/blue] fm {command}{sub_command}{element_example_data['benchname']}{code.format(**element_example_data)}")
-                examples_table.add_row(element_table)
-            return examples_table
+            element_table.add_row(f"[bold cyan]{desc.format(**example_data)}[/bold cyan]")
+            element_table.add_row(f"[blue]:play_button:[/blue] fm {' '.join(commands_stack)} {element_example_data['benchname']}{code.format(**element_example_data)}")
+            examples_table.add_row(element_table)
+        return examples_table

--- a/frappe_manager/utils/cli_examples.py
+++ b/frappe_manager/utils/cli_examples.py
@@ -1,0 +1,37 @@
+from typing import Dict, List
+import json
+from pathlib import Path
+import importlib.resources as pkg_resources
+
+import rich
+
+def get_frappe_manager_own_files(file_path: str):
+    return Path(str(pkg_resources.files("frappe_manager").joinpath(file_path)))
+
+def get_examples_from_toml(command_name: str, frappe_version: str, toml_path: Path = get_frappe_manager_own_files('./utils/examples.json')):
+    file_data = toml_path.read_bytes()
+    data: Dict[str,List[Dict[str,str]]] = json.loads(file_data)
+
+    example_data ={
+        'current_command' : command_name,
+        'benchname' : 'example.com',
+        'default_version' : frappe_version
+    }
+
+    from rich.table import Table
+
+    examples_table = Table(padding=(0,0),title=None,show_header=False,show_lines=False, box=None)
+
+    if command_name in data:
+
+        for element in data[command_name]:
+            desc = element.get('desc', 'None')
+            code = element.get('code', 'None')
+
+            element_table = Table(box=None,show_lines=False)
+
+            element_table.add_row(f"[bold cyan]{desc.format(**example_data)}[/bold cyan]")
+            element_table.add_row(f"[blue]:play_button:[/blue] {code.format(**example_data)}")
+            examples_table.add_row(element_table)
+
+        return examples_table

--- a/frappe_manager/utils/cli_examples.py
+++ b/frappe_manager/utils/cli_examples.py
@@ -1,20 +1,22 @@
-from typing import Dict, List
+from copy import deepcopy
+from typing import Dict, List, Optional
 import json
 from pathlib import Path
 import importlib.resources as pkg_resources
 
-import rich
-
 def get_frappe_manager_own_files(file_path: str):
     return Path(str(pkg_resources.files("frappe_manager").joinpath(file_path)))
 
-def get_examples_from_toml(command_name: str, frappe_version: str, toml_path: Path = get_frappe_manager_own_files('./utils/examples.json')):
+def get_examples_from_toml(command: str, frappe_version: str, toml_path: Path = get_frappe_manager_own_files('./utils/examples.json'), sub_command: Optional[str] = None ):
     file_data = toml_path.read_bytes()
     data: Dict[str,List[Dict[str,str]]] = json.loads(file_data)
 
+    bench_name = 'example.com'
+
     example_data ={
-        'current_command' : command_name,
-        'benchname' : 'example.com',
+        'command' : command,
+        'sub_command' : sub_command,
+        'benchname' : bench_name,
         'default_version' : frappe_version
     }
 
@@ -22,16 +24,33 @@ def get_examples_from_toml(command_name: str, frappe_version: str, toml_path: Pa
 
     examples_table = Table(padding=(0,0),title=None,show_header=False,show_lines=False, box=None)
 
-    if command_name in data:
+    if command in data:
+        examples_data = data[command]
 
-        for element in data[command_name]:
-            desc = element.get('desc', 'None')
-            code = element.get('code', 'None')
+        if isinstance(examples_data, dict):
+            if not sub_command:
+                if not 'examples'in examples_data:
+                    return None
+            else:
+                examples_data = examples_data[sub_command]
+                sub_command = f" {sub_command} "
+        else:
+            sub_command = ' '
 
-            element_table = Table(box=None,show_lines=False)
 
-            element_table.add_row(f"[bold cyan]{desc.format(**example_data)}[/bold cyan]")
-            element_table.add_row(f"[blue]:play_button:[/blue] {code.format(**example_data)}")
-            examples_table.add_row(element_table)
+        if examples_data:
+            element_example_data = deepcopy(example_data)
 
-        return examples_table
+            for element in examples_data:
+                desc = element.get('desc', 'None')
+                code = element.get('code', 'None')
+
+                if 'benchname' in element:
+                    element_example_data['benchname'] = element['benchname']
+
+                element_table = Table(box=None,show_lines=False)
+
+                element_table.add_row(f"[bold cyan]{desc.format(**example_data)}[/bold cyan]")
+                element_table.add_row(f"[blue]:play_button:[/blue] fm {command}{sub_command}{element_example_data['benchname']}{code.format(**element_example_data)}")
+                examples_table.add_row(element_table)
+            return examples_table

--- a/frappe_manager/utils/examples.json
+++ b/frappe_manager/utils/examples.json
@@ -1,154 +1,264 @@
 {
-  "create": [
-    {
-      "desc": "Install Frappe with the stable {default_version} branch.",
-      "code": "fm {current_command} {benchname}"
+  "create": {
+    "examples": [
+      {
+        "desc": "Install Frappe with the stable {default_version} branch.",
+        "code": ""
+      },
+      {
+        "desc": "Install Frappe with the develop branch.",
+        "code": " --frappe-branch develop"
+      },
+      {
+        "desc": "Install Frappe, ERPNext, and HRMS with the stable {default_version} branch.",
+        "code": " --apps erpnext --apps hrms"
+      },
+      {
+        "desc": "Install Frappe[{default_version}], ERPNext[{default_version}], and HRMS[develop].", "code": " --apps erpnext --apps hrms:develop"
+      },
+      {
+        "desc": "Use Frappe production mode based bench.",
+        "code": " --env prod"
+      },
+      {
+        "desc": "Enable Admin Tools.",
+        "code": " --admin-tools enable"
+      },
+      {
+        "desc": "Enable HTTPS using HTTP01 Let's Encrypt challenge certificate.",
+        "code": " --ssl letsencrypt --letsencrypt-preferred-challenge http01 --letsencrypt-email cloudflare@example.com"
+      },
+      {
+        "desc": "Enable HTTPS using DNS01 Let's Encrypt challenge certificate.",
+        "code": " --ssl letsencrypt --letsencrypt-preferred-challenge dns01"
+      }
+    ]
+  },
+  "delete": {
+    "examples": [
+      {
+        "desc": "Delete bench {benchname}",
+        "code": ""
+      }
+    ]
+  },
+  "stop": {
+    "examples": [
+      {
+        "desc": "Stop bench {benchname}",
+        "code": ""
+      }
+    ]
+  },
+  "info": {
+    "examples": [
+      {
+        "desc": "Show information about bench {benchname}",
+        "code": ""
+      }
+    ]
+  },
+  "list": {
+    "examples": [
+      {
+        "desc": "List all available benches",
+        "code": "fm {current_command}"
+      }
+    ]
+  },
+  "code": {
+    "examples": [
+      {
+        "desc": "Open the bench {benchname} in VSCode",
+        "code": ""
+      },
+      {
+        "desc": "Open the bench {benchname} with force start",
+        "code": " -f"
+      },
+      {
+        "desc": "Add custom extension other than default available",
+        "code": " -e vscodevim.vim"
+      },
+      {
+        "desc": "Sync vscode frapep debugger configuration",
+        "code": " -d"
+      },
+      {
+        "desc": "Use different workdir in vscode",
+        "code": " -w /workspace"
+      }
+    ]
+  },
+  "logs": {
+    "examples": [
+      {
+        "desc": "Show logs of Frappe server",
+        "code": ""
+      },
+      {
+        "desc": "Show logs of Frappe server and follow",
+        "code": " --follow"
+      },
+      {
+        "desc": "Show logs of NGINX container and follow",
+        "code": " --service nginx --follow"
+      }
+    ]
+  },
+  "shell": {
+    "examples": [
+      {
+        "desc": "Spawn shell for bench {benchname}, user - 'frappe', service - 'frappe'",
+        "code": ""
+      },
+      {
+        "desc": "Spawn shell for bench {benchname}, user - 'root', service - 'frappe'",
+        "code": " --user root"
+      },
+      {
+        "desc": "Spawn shell for bench {benchname}, user - 'root', service - 'nginx'",
+        "code": " --service nginx --user nginx"
+      }
+    ]
+  },
+  "start": {
+    "examples": [
+      {
+        "desc": "Start bench {benchname}",
+        "code": ""
+      }
+    ]
+  },
+  "update": {
+    "examples": [
+      {
+        "desc": "Enable SSL.",
+        "code": " --ssl letsencrypt"
+      },
+      {
+        "desc": "Enable HTTPS using HTTP01 Let's Encrypt challenge certificate.",
+        "code": " --ssl letsencrypt --letsencrypt-preferred-challenge http01 --letsencrypt-email cloudflare@example.com"
+      },
+      {
+        "desc": "Enable HTTPS using DNS01 Let's Encrypt challenge certificate.",
+        "code": " --ssl letsencrypt --letsencrypt-preferred-challenge dns01"
+      },
+      {
+        "desc": "Toggle admin-tools enable.",
+        "code": " --admin-tools enable"
+      },
+      {
+        "desc": "Toggle admin-tools disable.",
+        "code": " --admin-tools disable"
+      },
+      {
+        "desc": "Switch to frappe production environment.",
+        "code": " --env prod"
+      },
+      {
+        "desc": "Switch to frappe development environment.",
+        "code": " --environment dev"
+      },
+      {
+        "desc": "Enable frappe developer mode.",
+        "code": " --developer-mode enable"
+      },
+      {
+        "desc": "Disable frappe developer mode.",
+        "code": " --developer-mode disable"
+      }
+    ]
+  },
+  "services": {
+    "start": {
+      "examples": [
+        {
+          "desc": "Start global-db only.",
+          "code": " global-db"
+        },
+        {
+          "desc": "Start all global services",
+          "code": " all"
+        }
+      ]
     },
-    {
-      "desc": "Install Frappe with the develop branch.",
-      "code": "fm {current_command} {benchname} --frappe-branch develop"
+    "restart": {
+      "examples": [
+        {
+          "desc": "Restart global-db only.",
+          "code": " global-db"
+        },
+        {
+          "desc": "Restart all global services",
+          "code": " all"
+        }
+      ]
     },
-    {
-      "desc": "Install Frappe, ERPNext, and HRMS with the stable {default_version} branch.",
-      "code": "fm {current_command} {benchname} --apps erpnext --apps hrms"
+    "shell": {
+      "examples": [
+        {
+          "desc": "Shell global-db",
+          "code": " global-db"
+        },
+        {
+          "desc": "Shell global-nginx-proxy",
+          "code": " global-nginx-proxy"
+        }
+      ]
     },
-    {
-      "desc": "Install Frappe[{default_version}], ERPNext[{default_version}], and HRMS[develop].",
-      "code": "fm {current_command} {benchname} --apps erpnext --apps hrms:develop"
-    },
-    {
-      "desc": "Use Frappe production mode based bench.",
-      "code": "fm {current_command} {benchname} --env prod"
-    },
-    {
-      "desc": "Enable Admin Tools.",
-      "code": "fm {current_command} {benchname} --admin-tools enable"
-    },
-    {
-      "desc": "Enable HTTPS using HTTP01 Let's Encrypt challenge certificate.",
-      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge http01 --letsencrypt-email cloudflare@example.com"
-    },
-    {
-      "desc": "Enable HTTPS using DNS01 Let's Encrypt challenge certificate.",
-      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge dns01"
+    "stop": {
+      "examples": [
+        {
+          "desc": "Stop global-db",
+          "code": " global-db"
+        },
+        {
+          "desc": "Stop all services.",
+          "code": " all"
+        }
+      ]
     }
-  ],
-  "delete": [
-    {
-      "desc": "Delete bench {benchname}",
-      "code": "fm {current_command} {benchname}"
+  },
+  "ssl": {
+    "delete": {
+      "examples": [
+        {
+          "desc": "Delete {benchname}'s ssl certificate.",
+          "code": ""
+        }
+      ]
+    },
+    "renew": {
+      "examples": [
+        {
+          "desc": "Renew all certificates.",
+          "code": " --all",
+          "benchname": ""
+        },
+        {
+          "desc": "Renew specific {benchname} ssl certificate.",
+          "code": ""
+        }
+      ]
     }
-  ],
-  "stop": [
-    {
-      "desc": "Stop bench {benchname}",
-      "code": "fm {current_command} {benchname}"
+  },
+  "self": {
+    "update": {
+      "examples": [
+        {
+          "desc": "Update fm to the latest version available on pypi",
+          "code": ""
+        }
+      ],
+      "images": {
+        "examples": [
+          {
+            "desc": "Update all frappe required docker images.",
+            "code": ""
+          }
+        ]
+      }
     }
-  ],
-  "info": [
-    {
-      "desc": "Show information about bench {benchname}",
-      "code": "fm {current_command} {benchname}"
-    }
-  ],
-  "list": [
-    {
-      "desc": "List all available benches",
-      "code": "fm {current_command}"
-    }
-  ],
-  "code": [
-    {
-      "desc": "Open the bench {benchname} in VSCode",
-      "code": "fm {current_command} {benchname}"
-    },
-    {
-      "desc": "Open the bench {benchname} with force start",
-      "code": "fm {current_command} {benchname} -f"
-    },
-    {
-      "desc": "Add custom extension other than default available",
-      "code": "fm {current_command} {benchname} -e vscodevim.vim"
-    },
-    {
-      "desc": "Sync vscode frapep debugger configuration",
-      "code": "fm {current_command} {benchname} -d"
-    },
-    {
-      "desc": "Use different workdir in vscode",
-      "code": "fm {current_command} {benchname} -w /workspace"
-    }
-  ],
-  "logs": [
-    {
-      "desc": "Show logs of Frappe server",
-      "code": "fm {current_command} {benchname}"
-    },
-    {
-      "desc": "Show logs of Frappe server and follow",
-      "code": "fm {current_command} {benchname} --follow"
-    },
-    {
-      "desc": "Show logs of NGINX container and follow",
-      "code": "fm {current_command} {benchname} --service nginx --follow"
-    }
-  ],
-  "shell": [
-    {
-      "desc": "Spawn shell for bench {benchname}, user - 'frappe', service - 'frappe'",
-      "code": "fm {current_command} {benchname}"
-    },
-    {
-      "desc": "Spawn shell for bench {benchname}, user - 'root', service - 'frappe'",
-      "code": "fm {current_command} {benchname} --user root"
-    },
-    {
-      "desc": "Spawn shell for bench {benchname}, user - 'root', service - 'nginx'",
-      "code": "fm {current_command} {benchname} --service nginx --user nginx"
-    }
-  ],
-  "start": [
-    {
-      "desc": "Start bench {benchname}",
-      "code": "fm {current_command} {benchname}"
-    }
-  ],
-  "update": [
-    {
-      "desc": "Enable SSL.",
-      "code": "fm update {benchname} --ssl letsencrypt"
-    },
-    {
-      "desc": "Enable HTTPS using HTTP01 Let's Encrypt challenge certificate.",
-      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge http01 --letsencrypt-email cloudflare@example.com"
-    },
-    {
-      "desc": "Enable HTTPS using DNS01 Let's Encrypt challenge certificate.",
-      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge dns01"
-    },
-    {
-      "desc": "Toggle admin-tools enable.",
-      "code": "fm {current_command} {benchname} --admin-tools enable"
-    },
-    {
-      "desc": "Toggle admin-tools disable.",
-      "code": "fm {current_command} {benchname} --admin-tools disable"
-    },
-    {
-      "desc": "Switch to frappe production environment.",
-      "code": "fm {current_command} {benchname} --env prod"
-    },
-    {
-      "desc": "Switch to frappe development environment.",
-      "code": "fm {current_command} {benchname} --environment dev"
-    },
-    {
-      "desc": "Enable frappe developer mode.",
-      "code": "fm {current_command} {benchname} --developer-mode enable"
-    },
-    {
-      "desc": "Disable frappe developer mode.",
-      "code": "fm {current_command} {benchname} --developer-mode disable"
-    }
-  ]
+  }
 }

--- a/frappe_manager/utils/examples.json
+++ b/frappe_manager/utils/examples.json
@@ -62,7 +62,7 @@
     "examples": [
       {
         "desc": "List all available benches",
-        "code": "fm {current_command}"
+        "code": ""
       }
     ]
   },

--- a/frappe_manager/utils/examples.json
+++ b/frappe_manager/utils/examples.json
@@ -1,0 +1,154 @@
+{
+  "create": [
+    {
+      "desc": "Install Frappe with the stable {default_version} branch.",
+      "code": "fm {current_command} {benchname}"
+    },
+    {
+      "desc": "Install Frappe with the develop branch.",
+      "code": "fm {current_command} {benchname} --frappe-branch develop"
+    },
+    {
+      "desc": "Install Frappe, ERPNext, and HRMS with the stable {default_version} branch.",
+      "code": "fm {current_command} {benchname} --apps erpnext --apps hrms"
+    },
+    {
+      "desc": "Install Frappe[{default_version}], ERPNext[{default_version}], and HRMS[develop].",
+      "code": "fm {current_command} {benchname} --apps erpnext --apps hrms:develop"
+    },
+    {
+      "desc": "Use Frappe production mode based bench.",
+      "code": "fm {current_command} {benchname} --env prod"
+    },
+    {
+      "desc": "Enable Admin Tools.",
+      "code": "fm {current_command} {benchname} --admin-tools enable"
+    },
+    {
+      "desc": "Enable HTTPS using HTTP01 Let's Encrypt challenge certificate.",
+      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge http01 --letsencrypt-email cloudflare@example.com"
+    },
+    {
+      "desc": "Enable HTTPS using DNS01 Let's Encrypt challenge certificate.",
+      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge dns01"
+    }
+  ],
+  "delete": [
+    {
+      "desc": "Delete bench {benchname}",
+      "code": "fm {current_command} {benchname}"
+    }
+  ],
+  "stop": [
+    {
+      "desc": "Stop bench {benchname}",
+      "code": "fm {current_command} {benchname}"
+    }
+  ],
+  "info": [
+    {
+      "desc": "Show information about bench {benchname}",
+      "code": "fm {current_command} {benchname}"
+    }
+  ],
+  "list": [
+    {
+      "desc": "List all available benches",
+      "code": "fm {current_command}"
+    }
+  ],
+  "code": [
+    {
+      "desc": "Open the bench {benchname} in VSCode",
+      "code": "fm {current_command} {benchname}"
+    },
+    {
+      "desc": "Open the bench {benchname} with force start",
+      "code": "fm {current_command} {benchname} -f"
+    },
+    {
+      "desc": "Add custom extension other than default available",
+      "code": "fm {current_command} {benchname} -e vscodevim.vim"
+    },
+    {
+      "desc": "Sync vscode frapep debugger configuration",
+      "code": "fm {current_command} {benchname} -d"
+    },
+    {
+      "desc": "Use different workdir in vscode",
+      "code": "fm {current_command} {benchname} -w /workspace"
+    }
+  ],
+  "logs": [
+    {
+      "desc": "Show logs of Frappe server",
+      "code": "fm {current_command} {benchname}"
+    },
+    {
+      "desc": "Show logs of Frappe server and follow",
+      "code": "fm {current_command} {benchname} --follow"
+    },
+    {
+      "desc": "Show logs of NGINX container and follow",
+      "code": "fm {current_command} {benchname} --service nginx --follow"
+    }
+  ],
+  "shell": [
+    {
+      "desc": "Spawn shell for bench {benchname}, user - 'frappe', service - 'frappe'",
+      "code": "fm {current_command} {benchname}"
+    },
+    {
+      "desc": "Spawn shell for bench {benchname}, user - 'root', service - 'frappe'",
+      "code": "fm {current_command} {benchname} --user root"
+    },
+    {
+      "desc": "Spawn shell for bench {benchname}, user - 'root', service - 'nginx'",
+      "code": "fm {current_command} {benchname} --service nginx --user nginx"
+    }
+  ],
+  "start": [
+    {
+      "desc": "Start bench {benchname}",
+      "code": "fm {current_command} {benchname}"
+    }
+  ],
+  "update": [
+    {
+      "desc": "Enable SSL.",
+      "code": "fm update {benchname} --ssl letsencrypt"
+    },
+    {
+      "desc": "Enable HTTPS using HTTP01 Let's Encrypt challenge certificate.",
+      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge http01 --letsencrypt-email cloudflare@example.com"
+    },
+    {
+      "desc": "Enable HTTPS using DNS01 Let's Encrypt challenge certificate.",
+      "code": "fm {current_command} {benchname} --ssl letsencrypt --letsencrypt-preferred-challenge dns01"
+    },
+    {
+      "desc": "Toggle admin-tools enable.",
+      "code": "fm {current_command} {benchname} --admin-tools enable"
+    },
+    {
+      "desc": "Toggle admin-tools disable.",
+      "code": "fm {current_command} {benchname} --admin-tools disable"
+    },
+    {
+      "desc": "Switch to frappe production environment.",
+      "code": "fm {current_command} {benchname} --env prod"
+    },
+    {
+      "desc": "Switch to frappe development environment.",
+      "code": "fm {current_command} {benchname} --environment dev"
+    },
+    {
+      "desc": "Enable frappe developer mode.",
+      "code": "fm {current_command} {benchname} --developer-mode enable"
+    },
+    {
+      "desc": "Disable frappe developer mode.",
+      "code": "fm {current_command} {benchname} --developer-mode disable"
+    }
+  ]
+}

--- a/frappe_manager/utils/examples.json
+++ b/frappe_manager/utils/examples.json
@@ -248,14 +248,16 @@
       "examples": [
         {
           "desc": "Update fm to the latest version available on pypi",
-          "code": ""
+          "code": "",
+          "benchname": ""
         }
       ],
       "images": {
         "examples": [
           {
             "desc": "Update all frappe required docker images.",
-            "code": ""
+            "code": "",
+            "benchname": ""
           }
         ]
       }


### PR DESCRIPTION
Fixes: #186 
TODO:
- [x] Add examples for all commands
- [x] Beautify the examples printing.

Prev:
<img width="1440" alt="Screenshot 2024-05-31 at 3 27 31 PM" src="https://github.com/rtCamp/Frappe-Manager/assets/28294795/b2014211-b02a-423f-8d97-eeeadd4327bf">

Now:
<img width="1435" alt="Screenshot 2024-05-31 at 3 30 58 PM" src="https://github.com/rtCamp/Frappe-Manager/assets/28294795/8db0d447-5575-4b9f-a31e-1509b1380297">

