### PR TITLE
bump(docker)!: golang and python base images

### DIFF
--- a/Docker/mailhog/Dockerfile
+++ b/Docker/mailhog/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.22-alpine as builder
 
 LABEL org.opencontainers.image.source=https://github.com/rtcamp/Frappe-Manager
 

--- a/Docker/nginx/Dockerfile
+++ b/Docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11 as builder
+FROM python:3.12 as builder
 
 LABEL author=rtCamp
 LABEL org.opencontainers.image.source=https://github.com/rtcamp/Frappe-Manager


### PR DESCRIPTION
## Task Description

it upgrades the golang and python base images from 1.18 -> 1.22 and 3.11 -> 3.12 respectively