### PR TITLE
Fix `http01` challenge functionality and tag Docker images with specific versions

### DIFF
--- a/frappe_manager/templates/docker-compose.admin-tools.tmpl
+++ b/frappe_manager/templates/docker-compose.admin-tools.tmpl
@@ -9,7 +9,7 @@ services:
       site-network:
 
   adminer:
-    image: adminer:latest
+    image: adminer:4
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     environment:
       ADMINER_DEFAULT_SERVER: global-db

--- a/frappe_manager/templates/docker-compose.services.tmpl
+++ b/frappe_manager/templates/docker-compose.services.tmpl
@@ -27,7 +27,7 @@ services:
   global-nginx-proxy:
     container_name: fm_global-nginx-proxy
     user: REPLACE_WITH_CURRENT_USER:REPLACE_WITH_CURRENT_USER_GROUP
-    image: jwilder/nginx-proxy
+    image: jwilder/nginx-proxy:1.6
     environment:
       ACME_HTTP_CHALLENGE_LOCATION: false
     ports:

--- a/frappe_manager/templates/docker-compose.services.tmpl
+++ b/frappe_manager/templates/docker-compose.services.tmpl
@@ -28,6 +28,8 @@ services:
     container_name: fm_global-nginx-proxy
     user: REPLACE_WITH_CURRENT_USER:REPLACE_WITH_CURRENT_USER_GROUP
     image: jwilder/nginx-proxy
+    environment:
+      ACME_HTTP_CHALLENGE_LOCATION: false
     ports:
       - "80:80"
       - "443:443"

--- a/frappe_manager/templates/docker-compose.tmpl
+++ b/frappe_manager/templates/docker-compose.tmpl
@@ -87,7 +87,7 @@ services:
       global-backend-network:
 
   redis-cache:
-    image: redis:alpine
+    image: redis:6.2-alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     volumes:
       - redis-cache-data:/data
@@ -97,7 +97,7 @@ services:
       site-network:
 
   redis-queue:
-    image: redis:alpine
+    image: redis:6.2-alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     volumes:
       - redis-queue-data:/data
@@ -107,7 +107,7 @@ services:
       site-network:
 
   redis-socketio:
-    image: redis:alpine
+    image: redis:6.2-alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
     volumes:
        - redis-socketio-data:/data


### PR DESCRIPTION
- Fixes #197 
- Version tag docker images to latest version.