### PR TITLE
Feat: `reset` command

### DIFF
--- a/frappe_manager/commands.py
+++ b/frappe_manager/commands.py
@@ -635,7 +635,7 @@ def reset(
         typer.Option(help="Password for the 'Administrator' User."),
     ] = None,
 ):
-    """Reset bench db and reinstall apps from the apps directory to the bench site."""
+    """Reset bench site and reinstall all installed apps."""
 
     services_manager = ctx.obj["services"]
     verbose = ctx.obj['verbose']

--- a/frappe_manager/utils/examples.json
+++ b/frappe_manager/utils/examples.json
@@ -263,5 +263,13 @@
         ]
       }
     }
+  },
+  "reset": {
+    "examples": [
+      {
+        "desc": "Reset bench {benchname}",
+        "code": ""
+      }
+    ]
   }
 }

--- a/frappe_manager/utils/helpers.py
+++ b/frappe_manager/utils/helpers.py
@@ -1,10 +1,12 @@
 import importlib
+import json
 from cryptography.hazmat.backends import default_backend
 from datetime import datetime
 from cryptography import x509
 from io import StringIO
 import sys
 from typing import Optional
+from frappe_manager.site_manager.site_exceptions import BenchException
 from frappe_manager.utils.docker import run_command_with_exit_code
 import requests
 import subprocess
@@ -120,6 +122,7 @@ def check_and_display_port_status(ports_to_check: list, exclude=[]):
             richprint.exit(
                 f"Ports {', '.join(map(str, already_binded))} {'are' if len(already_binded) > 1 else 'is'} currently in use. Please free up these ports."
             )
+
 
 def generate_random_text(length=50):
     """
@@ -446,3 +449,20 @@ def get_certificate_expiry_date(fullchain_path: Path) -> datetime:
     else:
         expiry_date: datetime = cert.not_valid_after
     return expiry_date
+
+
+def save_dict_to_file(config: dict, json_file_path: Path):
+    """
+    Sets the config value in the json_file_path file.
+
+    Args:
+        config (dict): A dictionary containing the key-value pairs.
+    """
+
+    final_config = {}
+    with open(json_file_path, "r") as f:
+        final_config = json.load(f)
+    for key, value in config.items():
+        final_config[key] = value
+    with open(json_file_path, "w") as f:
+        json.dump(final_config, f)


### PR DESCRIPTION
**This PR:**
- Introduces `reset` command
- Internally this command reset the db of bench site and install all backend installed apps using `bench reinstall` command.

Command: `fm reset <benchname>`
Flags:
- `--admin-password` (optional): Admin password

**Command Flow/Process:**
1. Retrieve the admin password in the following order:
   - Use the `--admin-password` flag if provided.
   - Check the `admin_password` key in site_config.json.
   - Check the `admin_password` key in common_site_config.json.
   - Prompt the user for the admin password if not found in the above sources.
2. Reset the bench site using the obtained admin password.
3. Save the admin_password to site_config.json