### PR TITLE
Fix for `bench schedule` terminating < 1 seconds in supervisorctl

### DIFF
--- a/frappe_manager/site_manager/bench_operations.py
+++ b/frappe_manager/site_manager/bench_operations.py
@@ -197,6 +197,8 @@ class BenchOperations:
 
                 new_file: Path = supervisor_conf_path.parent / file_name
 
+                section_config.set(section_name, "startsecs", "0")
+
                 with open(new_file, "w") as section_file:
                     section_config.write(section_file)
 


### PR DESCRIPTION
The supervisorctl process for scheduler terminates with no errors, causing crons to fail. Possible fix for this issue. Adds \`[startsecs](http://supervisord.org/configuration.html#:~:text=Introduced%3A%203.0-,startsecs,-The%20total%20number)=0\` to the config so it doesn't despawn process.