### PR TITLE
Use native ruff server

### DIFF
--- a/frappe_manager/site_manager/__init__.py
+++ b/frappe_manager/site_manager/__init__.py
@@ -89,8 +89,8 @@ VSCODE_SETTINGS_JSON = {
         "editor.insertSpaces": True,
     },
     "ruff.organizeImports": True,
-    "ruff.fixAll": True,
-    "ruff.lint.run": "onSave",
+    "ruff.fixAll": True
+    "ruff.nativeServer": "auto",
 }
 
 PREBAKED_SITE_APPS = {


### PR DESCRIPTION
The old lsp ruff server is deprecated (https://docs.astral.sh/ruff/editors/settings/#lintrun)

We should probably use the nativeServer on the 'auto' setting which will fall back to the lsp server if the ruff version is too old.