### PR TITLE
feat: Add OCI image descriptions for multi-arch

### DIFF
--- a/Docker/build.sh
+++ b/Docker/build.sh
@@ -5,6 +5,9 @@ ARCH=$(uname -m)
 IMAGE_NAME_PREFIX="ghcr.io/rtcamp/frappe-manager"
 COMMAND='docker build --push'
 
+# OCI description for the multi-arch manifest (index). Override by exporting IMAGE_DESCRIPTION before running.
+IMAGE_DESCRIPTION=${IMAGE_DESCRIPTION:-"Frappe Manager multi-arch image with Bench tooling and pre-baked Frappe/ERPNext apps"}
+
 OTHER_ARCH="x86_64"
 if [[ "${ARCH}" == "x86_64" ]]; then
     ARCH="amd64"
@@ -36,11 +39,26 @@ for image in ${images}; do
 
 
         if [[ "${STATUS}" -eq 0 ]]; then
-            echo "Combining"
-            rm -rf ~/.docker/manifests
-            docker manifest create "${IMAGE_NAME}:${IMAGE_TAG}" \
-            --amend "${IMAGE_NAME_WITH_TAG}" \
-            --amend "${IMAGE_NAME}:${OTHER_ARCH}-${IMAGE_TAG}"
+            echo "Combining architectures into multi-arch manifest for ${IMAGE_NAME}:${IMAGE_TAG}"
+            rm -rf ~/.docker/manifests || true
+
+            if docker buildx imagetools create --help > /dev/null 2>&1; then
+                echo "Using buildx imagetools with OCI description annotation"
+                if ! docker buildx imagetools create \
+                    --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+                    --annotation "org.opencontainers.image.description=${IMAGE_DESCRIPTION}" \
+                    "${IMAGE_NAME_WITH_TAG}" "${IMAGE_NAME}:${OTHER_ARCH}-${IMAGE_TAG}"; then
+                    echo "[WARN] buildx imagetools create failed (maybe other arch not yet pushed). Falling back to docker manifest create without annotation." >&2
+                    docker manifest create "${IMAGE_NAME}:${IMAGE_TAG}" \
+                        --amend "${IMAGE_NAME_WITH_TAG}" \
+                        --amend "${IMAGE_NAME}:${OTHER_ARCH}-${IMAGE_TAG}" || true
+                fi
+            else
+                echo "[WARN] docker buildx imagetools not available; using docker manifest create (no description annotation)." >&2
+                docker manifest create "${IMAGE_NAME}:${IMAGE_TAG}" \
+                    --amend "${IMAGE_NAME_WITH_TAG}" \
+                    --amend "${IMAGE_NAME}:${OTHER_ARCH}-${IMAGE_TAG}" || true
+            fi
         fi
 
     fi

--- a/Docker/frappe/Dockerfile
+++ b/Docker/frappe/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04 AS bench
 
 LABEL author=rtCamp
 LABEL org.opencontainers.image.source=https://github.com/rtcamp/Frappe-Manager
+LABEL org.opencontainers.image.description="Base build stage for Frappe Manager providing Bench tooling and dependencies"
 
 ARG PYTHON_VERSIONS='3.12.0'
 ARG PYENV_GIT_VERSION='2.6.7'
@@ -186,6 +187,12 @@ COPY --from=prebake --chown=frappe:frappe /workspace/.nvm /workspace/.nvm
 COPY --from=prebake --chown=frappe:frappe /workspace/.oh-my-zsh /workspace/.oh-my-zsh
 
 FROM bench AS fm_image
+
+# OCI image metadata (applies to final image)
+LABEL author=rtCamp \
+    org.opencontainers.image.title="Frappe Manager" \
+    org.opencontainers.image.source="https://github.com/rtcamp/Frappe-Manager" \
+    org.opencontainers.image.description="Frappe Manager runtime image with pre-baked Frappe/ERPNext apps, bench tooling, wkhtmltopdf and supervisor"
 
 ENV WKHTMLTOPDF_VERSION=0.12.6.1-3
 RUN if [ "$(uname -m)" = "aarch64" ]; then export ARCH=arm64; fi \

--- a/Docker/nginx/Dockerfile
+++ b/Docker/nginx/Dockerfile
@@ -1,5 +1,8 @@
 FROM nginx:latest
 
+LABEL org.opencontainers.image.source="https://github.com/rtcamp/Frappe-Manager" \
+	org.opencontainers.image.description="Nginx reverse proxy for Frappe Manager with templated configuration and custom entrypoint"
+
 RUN apt update && DEBIAN_FONTEND=noninteractive apt install -y --no-install-recommends wait-for-it gosu python3 python3-pip && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -U jinja2-cli --break-system-packages
 


### PR DESCRIPTION
This pull request enhances the Docker images for Frappe Manager by adding standardized Open Container Initiative (OCI) metadata annotations and improving the build process for multi-architecture images. These changes make the images more informative and compliant with best practices, and improve the reliability of multi-arch manifest creation.

**OCI metadata annotation improvements:**

* Added OCI-compliant labels such as `org.opencontainers.image.description`, `org.opencontainers.image.source`, and `org.opencontainers.image.title` to `Docker/frappe/Dockerfile` (both build and final stages) and `Docker/nginx/Dockerfile` to provide better image documentation and provenance. [[1]](diffhunk://#diff-4e339c68cf9289541d1ecc6f8669600e4e9ab5c9ba891a0fd842280a9a373ce2R5) [[2]](diffhunk://#diff-4e339c68cf9289541d1ecc6f8669600e4e9ab5c9ba891a0fd842280a9a373ce2R191-R196) [[3]](diffhunk://#diff-5d7e6c5b5a901bba13bdf00852624cd2d39296df524f0635a06a2c62c835e947R3-R5)

**Multi-architecture build enhancements:**

* Introduced the `IMAGE_DESCRIPTION` variable and logic in `Docker/build.sh` to annotate the multi-arch manifest with a description, and added fallback mechanisms for manifest creation when `buildx imagetools` is unavailable. This improves the robustness of multi-arch image publishing and ensures OCI description annotations are included when possible. [[1]](diffhunk://#diff-7b9e1e871da81acf76ae84ee82cb2a237cfe89cb9d4819d04c8a5277969ae379R8-R10) [[2]](diffhunk://#diff-7b9e1e871da81acf76ae84ee82cb2a237cfe89cb9d4819d04c8a5277969ae379L39-R61)