### PR TITLE
Update helpers.py

### DIFF
--- a/frappe_manager/utils/helpers.py
+++ b/frappe_manager/utils/helpers.py
@@ -12,7 +12,10 @@ import subprocess
 import platform
 import time
 import secrets
-import grp
+if platform.system() != "Windows":
+    import grp
+else:
+    grp = None
 from pathlib import Path
 import importlib.resources as pkg_resources
 from rich.console import Console
@@ -304,6 +307,9 @@ def random_password_generate(password_length=13, symbols=False):
 
 # Retrieve Unix groups and their corresponding integer mappings
 def get_unix_groups():
+    if grp is None:
+        richprint.warn("Unix group info not available on Windows.")
+        return {}
     groups = {}
     for group_entry in grp.getgrall():
         group_name = group_entry.gr_name


### PR DESCRIPTION
## Fix : Does not work on Windows as there is a dependency on grp #289
Fix: Skip grp import on Windows to enable cross-platform CLI usage
## PR Description:
This patch improves cross-platform compatibility by conditionally importing the Unix-only grp module in helpers.py. On Windows systems, the CLI previously failed due to ImportError. This fix:
- [x] Adds a platform check to safely skip grp import on Windows
- [x] Returns an empty dictionary from get_unix_groups() when grp is unavailable
- [x] Warns users via richprint.warn that Unix group info is not available on Windows

This allows the CLI to run natively on Windows without crashing, while preserving full functionality on Unix-based systems.

Let me know if you'd prefer a fallback behavior or stricter handling. Happy to iterate!