### PR TITLE
Remove deprecated ruff.lint.run setting from autogenerated .vscode/settings.json

### DIFF
--- a/frappe_manager/site_manager/__init__.py
+++ b/frappe_manager/site_manager/__init__.py
@@ -83,14 +83,13 @@ VSCODE_SETTINGS_JSON = {
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": True,
-        "editor.codeActionsOnSave": {"source.fixAll": True, "source.organizeImports": True},
+        "editor.codeActionsOnSave": {"source.fixAll": "always", "source.organizeImports": "always"},
         "editor.detectIndentation": True,
         "editor.tabSize": 4,
         "editor.insertSpaces": True,
     },
     "ruff.organizeImports": True,
     "ruff.fixAll": True,
-    "ruff.lint.run": "onSave",
 }
 
 PREBAKED_SITE_APPS = {


### PR DESCRIPTION
fixes #307 

Verified auto formatting & import organisation on save. No `ruff lsp` warnings.