### PR TITLE
fix: Activate NVM and pyenv in entrypoint to fix node PATH issue

### DIFF
--- a/Docker/frappe/entrypoint.sh
+++ b/Docker/frappe/entrypoint.sh
@@ -3,11 +3,16 @@ source /scripts/helper-function.sh
 
 # Activate NVM to make node available in PATH
 if [[ -d "$NVM_DIR" ]]; then
+    # Check if NODE_VERSIONS is set
+    if [[ -z "${NODE_VERSIONS:-}" ]]; then
+        echo "[ERROR] NODE_VERSIONS environment variable is not set" >&2
+        exit 1
+    fi
     export NODE_VERSION="${NODE_VERSIONS%% *}"
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 fi
 
-# Activate pyenv to make python available in PATH  
+# Activate pyenv to make python available in PATH
 if [[ -d "$PYENV_ROOT" ]]; then
     export PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init --path)"
@@ -39,9 +44,10 @@ SOCK_SERVICE_PATH="$SOCK_DIR/$SERVICE_NAME.sock"
 
 echo "Setting supervisord sock directory to $SOCK_SERVICE_PATH"
 mkdir -p $SOCK_DIR
-chown "$USERID:$USERGROUP" $SOCK_DIR /opt/user /opt/user/conf.d
-rm -rf "$SOCK_SERVICE_PATH"
 
+chown "$USERID:$USERGROUP" $SOCK_DIR /opt/user /opt/user/conf.d
+
+rm -rf "$SOCK_SERVICE_PATH"
 sed -i "s/\opt\/user\/supervisor\.sock/fm-sockets\/${SERVICE_NAME}\.sock/g" /opt/user/supervisord.conf
 
 echo "supervisord configured $?"
@@ -55,5 +61,4 @@ else
 fi
 
 configure_workspace
-
 wait $running_script_pid

--- a/Docker/frappe/entrypoint.sh
+++ b/Docker/frappe/entrypoint.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-
 source /scripts/helper-function.sh
+
+# Activate NVM to make node available in PATH
+if [[ -d "$NVM_DIR" ]]; then
+    export NODE_VERSION="${NODE_VERSIONS%% *}"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+fi
+
+# Activate pyenv to make python available in PATH  
+if [[ -d "$PYENV_ROOT" ]]; then
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init --path)"
+fi
 
 cleanup() {
     echo "Received signal SIGTERM, stopping..."
@@ -21,20 +32,18 @@ fi
 [[ "${SERVICE_NAME:-}" ]] || emer "[ERROR] Please provide SERVICE_NAME environment variable."
 
 echo "Setting up user"
-
 update_uid_gid "${USERID}" "${USERGROUP}" "frappe" "frappe"
 
 SOCK_DIR='/fm-sockets'
 SOCK_SERVICE_PATH="$SOCK_DIR/$SERVICE_NAME.sock"
 
 echo "Setting supervisord sock directory to $SOCK_SERVICE_PATH"
-
 mkdir -p $SOCK_DIR
 chown "$USERID:$USERGROUP" $SOCK_DIR /opt/user /opt/user/conf.d
-
 rm -rf "$SOCK_SERVICE_PATH"
 
 sed -i "s/\opt\/user\/supervisor\.sock/fm-sockets\/${SERVICE_NAME}\.sock/g" /opt/user/supervisord.conf
+
 echo "supervisord configured $?"
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
Fixes #294

This commit activates NVM and pyenv early in the entrypoint.sh script to ensure that node and python binaries are available in the PATH for all subsequent operations, including subprocess calls from Python scripts.

Previously, when Python scripts used subprocess.run() to call node commands, they would fail with FileNotFoundError because NVM was only sourced in bash/zsh config files, not in the subprocess environment.