### PR TITLE
Ensure restart policy for services

### DIFF
--- a/frappe_manager/templates/docker-compose.admin-tools.tmpl
+++ b/frappe_manager/templates/docker-compose.admin-tools.tmpl
@@ -2,6 +2,7 @@ services:
   mailpit:
     image: axllent/mailpit:v1.22
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     volumes:
       - mailpit-data:/data
     expose:
@@ -19,6 +20,7 @@ services:
   adminer:
     image: adminer:4
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     expose:
       - 8080
     networks:

--- a/frappe_manager/templates/docker-compose.tmpl
+++ b/frappe_manager/templates/docker-compose.tmpl
@@ -2,6 +2,7 @@ services:
   frappe:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.18.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     environment:
       USERID: REPLACE_ME_WITH_CURRENT_USER
       USERGROUP: REPLACE_ME_WITH_CURRENT_USER_GROUP
@@ -20,6 +21,7 @@ services:
   nginx:
     image: ghcr.io/rtcamp/frappe-manager-nginx:v0.18.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     user: REPLACE_ME_WITH_CURRENT_USER:REPLACE_ME_WITH_CURRENT_USER_GROUP
     environment:
       SITENAME: REPLACE_ME_WITH_THE_SITE_NAME
@@ -42,6 +44,7 @@ services:
   socketio:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.18.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     environment:
       USERID: REPLACE_ME_WITH_CURRENT_USER
       USERGROUP: REPLACE_ME_WITH_CURRENT_USER_GROUP
@@ -58,6 +61,7 @@ services:
   schedule:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.18.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     environment:
       USERID: REPLACE_ME_WITH_CURRENT_USER
       USERGROUP: REPLACE_ME_WITH_CURRENT_USER_GROUP
@@ -73,6 +77,7 @@ services:
   redis-cache:
     image: redis:8-alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     volumes:
       - redis-cache-data:/data
     expose:
@@ -83,6 +88,7 @@ services:
   redis-queue:
     image: redis:8-alpine
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     volumes:
       - redis-queue-data:/data
     expose:

--- a/frappe_manager/templates/docker-compose.workers.tmpl
+++ b/frappe_manager/templates/docker-compose.workers.tmpl
@@ -2,6 +2,7 @@ services:
   worker-name:
     image: ghcr.io/rtcamp/frappe-manager-frappe:v0.18.0
     container_name: REPLACE_ME_WITH_CONTAINER_NAME
+    restart: unless-stopped
     command: launch_supervisor_service.sh
     networks:
       site-network:


### PR DESCRIPTION
Fixes: https://github.com/rtCamp/Frappe-Manager/issues/316

This PR fixes a critical issue where Docker containers don't automatically restart after server reboot, causing complete service outages until manual intervention.

## Changes Made

Added `restart: unless-stopped` policy to all services across three Docker Compose template files:

### 1. docker-compose.tmpl (Site Services)
- ✅ frappe - Added restart policy
- ✅ nginx - Added restart policy
- ✅ socketio - Added restart policy
- ✅ schedule - Added restart policy
- ✅ redis-cache - Added restart policy
- ✅ redis-queue - Added restart policy

### 2. docker-compose.workers.tmpl (Worker Services)
- ✅ worker-name - Added restart policy

### 3. docker-compose.admin-tools.tmpl (Admin Tools)
- ✅ mailpit - Added restart policy
- ✅ adminer - Added restart policy

### 4. docker-compose.services.tmpl (Global Services)
- ✅ global-db - Already has `restart: always` (no change needed)
- ✅ global-nginx-proxy - Already has `restart: always` (no change needed)
