### PR TITLE
nginx: move to alpine

### DIFF
--- a/Docker/nginx/Dockerfile
+++ b/Docker/nginx/Dockerfile
@@ -1,6 +1,8 @@
-FROM nginx:latest
+FROM nginx:alpine
 
-RUN apt update && DEBIAN_FONTEND=noninteractive apt install -y --no-install-recommends wait-for-it gosu python3 python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apk update && DEBIAN_FONTEND=noninteractive apk add --no-cache python3 py3-pip bash && \
+    curl -o /usr/local/bin/wait-for-it https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it
 RUN pip install --no-cache-dir -U jinja2-cli --break-system-packages
 
 COPY template.conf /config/


### PR DESCRIPTION
Previous one was ~220 mb
Now with alpine ~120mb
    
Saving storage, network call, time
    
This pull request updates the Docker setup for Nginx and enhances MySQL configuration in the Docker Compose templates. The main improvements are switching to a lighter Nginx image and adding MySQL binary logging options for better data durability and replication support.

**Docker image and dependency updates:**

* Changed the base image in `Docker/nginx/Dockerfile` from `nginx:latest` to `nginx:alpine` for a smaller footprint and faster builds. Also migrated package installation from `apt` to `apk`, adjusted dependencies, and updated how `wait-for-it` is installed.

**MySQL configuration enhancements:**

* Added MySQL binary logging options (`--log-bin=mysql-bin`, `--expire-logs-days=10`, `--max-binlog-size=100M`) to both `frappe_manager/templates/docker-compose.services.tmpl` and `frappe_manager/templates/docker-compose.services.osx.tmpl` for improved backup and replication capabilities. [[1]](diffhunk://#diff-9d44aff01c5c84c2ba0431346751fac6af2487da8afdebcc5dd5a3eb356f7ee0R12-R14) [[2]](diffhunk://#diff-50be6b37c71a06f4550729448a3de7fdb90e76beea4af737901b13af5c6a739dR12-R14)