### PR TITLE
fix: AttributeError in `BenchOperationFrappeBranchChangeFailed` exception

### DIFF
--- a/frappe_manager/site_manager/site_exceptions.py
+++ b/frappe_manager/site_manager/site_exceptions.py
@@ -253,13 +253,13 @@ class BenchOperationException(BenchException):
         super().__init__(self.bench_name, self.message, prefix_bench_name=False)
 
 
-class BenchOperationFrappeBranchChangeFailed(BenchException):
-    def __init__(self, bench_name, app: str, branch: str, message: str = "Failed to change {} app branch to {}."):
+class BenchOperationFrappeBranchChangeFailed(BenchOperationException):
+    def __init__(self, bench_name, app: str, branch: str, message: str = "Failed to change {} app branch to {}.", print_combined: bool = True, print_stdout: bool = False, print_stderr: bool = False):
         self.bench_name = bench_name
         self.app = app
         self.branch = branch
-        self.message = message.format(app, branch)
-        super().__init__(self.bench_name, self.message)
+        self. message = message.format(app, branch)
+        super().__init__(self.bench_name, self.message, print_combined, print_stdout, print_stderr)
 
 
 class BenchOperationRequiredDockerImagesNotAvailable(BenchException):

--- a/frappe_manager/site_manager/site_exceptions.py
+++ b/frappe_manager/site_manager/site_exceptions.py
@@ -259,6 +259,9 @@ class BenchOperationFrappeBranchChangeFailed(BenchOperationException):
         self.app = app
         self.branch = branch
         self.message = message.format(app, branch)
+        self.print_combined = print_combined
+        self.print_stdout = print_stdout
+        self.print_stderr = print_stderr
         super().__init__(self.bench_name, self.message, print_combined, print_stdout, print_stderr)
 
 

--- a/frappe_manager/site_manager/site_exceptions.py
+++ b/frappe_manager/site_manager/site_exceptions.py
@@ -258,7 +258,7 @@ class BenchOperationFrappeBranchChangeFailed(BenchOperationException):
         self.bench_name = bench_name
         self.app = app
         self.branch = branch
-        self. message = message.format(app, branch)
+        self.message = message.format(app, branch)
         super().__init__(self.bench_name, self.message, print_combined, print_stdout, print_stderr)
 
 


### PR DESCRIPTION
## Fix AttributeError in `BenchOperationFrappeBranchChangeFailed` exception

### Problem
The application crashes with an `AttributeError: 'BenchOperationFrappeBranchChangeFailed' object has no attribute 'set_output'` when attempting to change the Frappe branch during bench operations.

### Root Cause
The `BenchOperationFrappeBranchChangeFailed` exception class inherits from `BenchException` instead of `BenchOperationException`. When this exception is passed to the `container_run()` method in `bench_operations.py` (line 163), the method attempts to call `set_output()` on it (line 138), but this method only exists in the `BenchOperationException` class.

### Solution
- Change `BenchOperationFrappeBranchChangeFailed` to inherit from `BenchOperationException` instead of `BenchException`
- Add the required output control parameters (`print_combined`, `print_stdout`, `print_stderr`) to match the parent class interface
- Update the `super().__init__()` call to properly pass all required parameters

### Changes
- **File**: `frappe_manager/site_manager/site_exceptions. py`
- Modified the `BenchOperationFrappeBranchChangeFailed` class to properly extend `BenchOperationException`

### Testing
This fix ensures that:
- The exception can be properly handled by `container_run()` method
- Output from failed operations is properly captured and displayed
- No AttributeError is raised when changing Frappe branches

Before
<img width="872" height="58" alt="image" src="https://github.com/user-attachments/assets/42ec0929-31f7-4af9-b605-ebc538fe1853" />


After
<img width="1414" height="382" alt="image" src="https://github.com/user-attachments/assets/bfdbe778-5ce2-4650-a3c8-4cf7a39a2d5d" />

