### PR TITLE
chore: Update Pyenv and NVM versions in Dockerfile

### DIFF
--- a/Docker/frappe/Dockerfile
+++ b/Docker/frappe/Dockerfile
@@ -4,9 +4,9 @@ LABEL author=rtCamp
 LABEL org.opencontainers.image.source=https://github.com/rtcamp/Frappe-Manager
 
 ARG PYTHON_VERSIONS='3.12.0'
-ARG PYENV_GIT_VERSION='2.6.7'
+ARG PYENV_GIT_VERSION='2.6.17'
 ARG PYENV_ROOT='/workspace/.pyenv'
-ARG NVM_VERSION='0.39.0'
+ARG NVM_VERSION='0.40.3'
 ARG NVM_DIR='/workspace/.nvm'
 ARG NODE_VERSIONS='22.18.0'
 ARG PREBAKE_APPS='erpnext:version-15,hrms:version-15'


### PR DESCRIPTION
This pull request updates the versions of some core dependencies in the `Docker/frappe/Dockerfile` to ensure compatibility and access to the latest features and fixes.

Dependency version updates:

* Updated `PYENV_GIT_VERSION` from `2.6.7` to `2.6.17` to bring in the latest improvements and bug fixes for pyenv.
* Updated `NVM_VERSION` from `0.39.0` to `0.40.3` to use the latest version of Node Version Manager.

Needed to download python 3.14 required by frappe version-16 since pyenv 2.6.7 doesn't have python 3.14