### PR TITLE
fix: use `frappe_site_name` for asset resolution instead of `host`

### DIFF
--- a/Docker/nginx/template.conf
+++ b/Docker/nginx/template.conf
@@ -73,10 +73,10 @@ server {
 
 		location ~* ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";
-			try_files /$host/public/$uri @webserver;
+			try_files /$frappe_site_name/public/$uri @webserver;
 		}
 
-		try_files /$host/public/$uri @webserver;
+		try_files /$frappe_site_name/public/$uri @webserver;
 	}
 
 	location @webserver {


### PR DESCRIPTION
This pull request updates the Nginx configuration template to improve variable usage for file serving and routing. The most important change is replacing the `$host` variable with `$frappe_site_name` to ensure correct file path resolution.

Configuration improvements:

* Replaced `$host` with `$frappe_site_name` in `try_files` directives for both the `/files/` location block and the main location block in `Docker/nginx/template.conf`, ensuring files are served from the correct site-specific directory.