### PR TITLE
Add ENV fixes to docker scripts

### DIFF
--- a/Docker/frappe/Dockerfile
+++ b/Docker/frappe/Dockerfile
@@ -189,6 +189,7 @@ RUN mkdir -p /etc/profile.d && \
     echo 'if [ -d "/workspace/.uv/python-default/bin" ]; then' >> /etc/profile.d/fnm.sh && \
     echo '    export PATH="/workspace/.uv/python-default/bin:$PATH"' >> /etc/profile.d/fnm.sh && \
     echo 'fi' >> /etc/profile.d/fnm.sh && \
+    echo 'export PATH="/opt/user/.bin:$PATH"' >> /etc/profile.d/fnm.sh && \
     chmod +x /etc/profile.d/fnm.sh && \
     echo '' >> /etc/bash.bashrc && \
     echo '. /etc/profile.d/fnm.sh' >> /etc/bash.bashrc

--- a/Docker/frappe/launch_supervisor_service.sh
+++ b/Docker/frappe/launch_supervisor_service.sh
@@ -75,7 +75,7 @@ if [[ "${CHANGE_DIR:-}" ]]; then
 	cd "$CHANGE_DIR" || true
 fi
 
-source /env/bash.bashrc
+source /etc/bash.bashrc
 
 if $all_files_exist; then
 	echo "$file_to_check populated within $total_iteration seconds."

--- a/frappe_manager/site_manager/modules/bench_app.py
+++ b/frappe_manager/site_manager/modules/bench_app.py
@@ -278,9 +278,11 @@ fi
                             use_run=use_run,
                         )
                         if result and result.exit_code == 0 and result.combined:
-                            selected_python_full = result.combined[0].strip()
+                            selected_python_full = result.stdout[0].strip()
                         else:
                             selected_python_full = f"cpython-{python_version}"
+
+                        print(selected_python_full)
 
                         self.output.print(f"Installed Python {python_version} via uv")
 

--- a/frappe_manager/site_manager/modules/bench_app.py
+++ b/frappe_manager/site_manager/modules/bench_app.py
@@ -282,8 +282,6 @@ fi
                         else:
                             selected_python_full = f"cpython-{python_version}"
 
-                        print(selected_python_full)
-
                         self.output.print(f"Installed Python {python_version} via uv")
 
                     if selected_python_full:


### PR DESCRIPTION
Environment setup and PATH configuration:

* Added `/opt/user/.bin` to the `PATH` in the shell profile script (`/etc/profile.d/fnm.sh`) to ensure binaries in this directory are available in all shell sessions.

Script sourcing consistency:

* Changed the sourced bash configuration in `launch_supervisor_service.sh` from `/env/bash.bashrc` to `/etc/bash.bashrc` to align with the standard system location and ensure environment variables are loaded correctly.

Python environment detection:

* Updated the method for selecting the Python executable in `bench_app.py` to use `result.stdout` instead of `result.combined`, improving the accuracy of environment detection.