### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-migration.yml
+++ b/.github/workflows/e2e-migration.yml
@@ -7,6 +7,9 @@ on:
       - develop
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/Frappe-Manager/security/code-scanning/15](https://github.com/rtCamp/Frappe-Manager/security/code-scanning/15)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow or to each job, specifying the minimal scopes required. For this workflow, the jobs only need to read repository contents (for `actions/checkout`) and do not appear to interact with issues, PRs, or packages using `GITHUB_TOKEN`, so `contents: read` is a good minimal baseline.

The simplest, non‑behavior‑changing fix is to define a workflow‑level `permissions` block right after the `on:` section. This will apply to all jobs (`e2e-migration-from-0_9_0-to-latest` and `e2e-migration-from-before_latest-to-latest`) without needing to repeat configuration and will resolve the CodeQL finding for line 79 as well as for the first job. Concretely, in `.github/workflows/e2e-migration.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–8) and the `concurrency:` block (lines 10–12). No additional imports, methods, or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
