### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bake-images.yml
+++ b/.github/workflows/bake-images.yml
@@ -1,5 +1,8 @@
 name: Publish image
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 2 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/Frappe-Manager/security/code-scanning/5](https://github.com/rtCamp/Frappe-Manager/security/code-scanning/5)

In general, the fix is to explicitly declare `permissions` in the workflow (either at the top level for all jobs, or per job) and restrict `GITHUB_TOKEN` to the minimum necessary, typically `contents: read` for workflows that only need to read repository data. This both documents the required permissions and prevents unintended privilege escalation if repo defaults change.

For this specific workflow, neither `build-and-push` nor `combine` require repository write operations through `GITHUB_TOKEN`. They read the repository (checkout) and then use Docker and `secrets.GHCR_USER`/`secrets.GHCR_TOKEN` to push to GHCR. Thus, a minimal and appropriate permission set is `contents: read`. The cleanest approach that does not alter functionality is to define a root‑level `permissions` block applying to all jobs.

Concretely:
- Edit `.github/workflows/bake-images.yml`.
- Immediately after the `name: Publish image` line, add:

  ```yaml
  permissions:
    contents: read
  ```

This will apply to both `build-and-push` and `combine` jobs and limit `GITHUB_TOKEN` to read‑only repository contents, which is sufficient for `actions/checkout` to work and does not interfere with Docker operations using your explicit secrets.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
