### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-site.yaml
+++ b/.github/workflows/e2e-site.yaml
@@ -8,6 +8,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   check-permissions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/Frappe-Manager/security/code-scanning/12](https://github.com/rtCamp/Frappe-Manager/security/code-scanning/12)

In general, the fix is to explicitly declare a `permissions` block limiting the `GITHUB_TOKEN` to the minimal scopes needed, either at the workflow root (applies to all jobs) or per job. For this workflow, the jobs only need to read repository contents and use artifacts; they do not push or modify GitHub resources, so read-only `contents` (and default read for others) is sufficient.

The single best fix without changing functionality is to add a workflow-level `permissions` block just after the `on:` section, with `contents: read`. This will apply to both `check-permissions` and `e2e-current` since neither defines their own permissions, and it directly addresses the CodeQL warning on `e2e-current` (line 23) by constraining `GITHUB_TOKEN`. Concretely, edit `.github/workflows/e2e-site.yaml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–9) and the `jobs:` block (line 11). No additional imports or methods are needed because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
