### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-site.yaml
+++ b/.github/workflows/e2e-site.yaml
@@ -1,5 +1,8 @@
 name: E2E site testing
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/Frappe-Manager/security/code-scanning/11](https://github.com/rtCamp/Frappe-Manager/security/code-scanning/11)

In general, the problem is fixed by explicitly declaring a minimal `permissions` block so the `GITHUB_TOKEN` has only the scopes required. For a test workflow like this that only needs to read the repository contents and interact with caches and artifacts, `contents: read` is sufficient; no write permissions are required.

The best way to fix this without changing behavior is to add a root-level `permissions` block to `.github/workflows/e2e-site.yaml` so it applies to all jobs (`check-permissions` and `e2e-current`). Place it near the top of the file, after `name:` and before `on:`. Set `permissions: contents: read`, which allows `actions/checkout` and the other actions to work, while preventing unnecessary write access to repository contents or other resources. No additional methods, imports, or definitions are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
