### PR TITLE
fix: quote workdir before bash -c interpolation to prevent command injection

### DIFF
--- a/frappe_manager/site_manager/modules/bench_app.py
+++ b/frappe_manager/site_manager/modules/bench_app.py
@@ -867,7 +867,7 @@ fi
         """
         try:
             if use_run:
-                wrapped_command = f"cd {workdir} && {command}"
+                wrapped_command = f"cd {shlex.quote(workdir)} && {command}"
                 run_command = f"/bin/bash -c '{wrapped_command}'"
                 if capture_output:
                     output = cast(

--- a/frappe_manager/site_manager/modules/bench_site.py
+++ b/frappe_manager/site_manager/modules/bench_site.py
@@ -8,6 +8,7 @@ Extracted from the monolithic Bench class and BenchOperations for better
 separation of concerns.
 """
 
+import shlex
 from collections.abc import Iterator
 from pathlib import Path
 from typing import cast
@@ -309,7 +310,7 @@ class BenchSiteManager:
         """
         try:
             if use_run:
-                wrapped_command = f"cd {workdir} && {command}"
+                wrapped_command = f"cd {shlex.quote(workdir)} && {command}"
                 run_command = f"/bin/bash -c '{wrapped_command}'"
                 if capture_output:
                     output = cast(


### PR DESCRIPTION
## Summary

Both `BenchAppManager.exec` and `BenchSiteManager.exec` construct a Docker shell command:

```python
wrapped_command = f"cd {workdir} && {command}"
run_command = f"/bin/bash -c '{wrapped_command}'"
```

An uncontrolled `workdir` value containing shell metacharacters (e.g. `'; rm -rf /;'`, `$(cmd)`) would break out of the `cd` argument and execute arbitrary commands inside the container.

## Changes

Apply `shlex.quote(workdir)` before interpolation in both files:

```python
wrapped_command = f"cd {shlex.quote(workdir)} && {command}"
```

`shlex` was already imported in `bench_app.py`; added the import to `bench_site.py`.

## Test plan

- [ ] Confirm existing Docker exec flows work with typical workdir paths (e.g. `/workspace/site`)
- [ ] Verify a workdir with spaces is correctly passed as a quoted shell argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)