### PR TITLE
ci: fix pages deployment - alias redirect and CNAME from var

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,8 +15,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -50,6 +48,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Set custom domain
+        if: vars.PAGES_CNAME != ''
+        run: echo "${{ vars.PAGES_CNAME }}" > docs/CNAME
       - name: Resolve version slug from __about__.py
         id: ver
         run: |
@@ -84,10 +85,3 @@ jobs:
       - name: Set default version to dev (develop branch)
         if: github.ref == 'refs/heads/develop'
         run: mike set-default --push dev -F zensical.toml
-      - name: Ensure custom domain is set
-        if: vars.PAGES_CNAME != ''
-        run: |
-          gh api repos/${{ github.repository }}/pages --jq '.cname' | grep -qF "${{ vars.PAGES_CNAME }}" || \
-          gh api --method PATCH repos/${{ github.repository }}/pages -f cname="${{ vars.PAGES_CNAME }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,7 +65,7 @@ jobs:
           echo "slug=$slug" >> $GITHUB_OUTPUT
       - name: Deploy versioned docs (release tag)
         if: startsWith(github.ref, 'refs/tags/v')
-        run: mike deploy --push --update-aliases --title "${{ steps.ver.outputs.slug }}" ${{ steps.ver.outputs.slug }} latest -F zensical.toml
+        run: mike deploy --push --update-aliases --alias-type redirect --title "${{ steps.ver.outputs.slug }}" ${{ steps.ver.outputs.slug }} latest -F zensical.toml
       - name: Deploy dev docs (develop branch)
         if: github.ref == 'refs/heads/develop'
         run: |
@@ -78,7 +78,7 @@ jobs:
                   print(v['version'])
           ")
           [ -n "$stale" ] && mike delete --push "$stale" -F zensical.toml || true
-          mike deploy --push --update-aliases --title "${{ steps.ver.outputs.full }}" ${{ steps.ver.outputs.full }} dev -F zensical.toml
+          mike deploy --push --update-aliases --alias-type redirect --title "${{ steps.ver.outputs.full }}" ${{ steps.ver.outputs.full }} dev -F zensical.toml
       - name: Set default version to latest (release tag)
         if: startsWith(github.ref, 'refs/tags/v')
         run: mike set-default --push latest -F zensical.toml


### PR DESCRIPTION
Fixes two remaining issues in the pages deployment workflow:

- Add `--alias-type redirect` to both `mike deploy` calls so mkdocs instant navigation works correctly on GitHub Pages (symlink aliases are not followed by the CDN, causing full page reloads)
- Move custom domain setup before `mike deploy` so the `docs/CNAME` file is included in the built site output — replaces the previous GitHub API approach