### PR TITLE
Add NewRelic APM integration and refactor Python dependency installation

### DIFF
--- a/frappe_manager/commands/create.py
+++ b/frappe_manager/commands/create.py
@@ -141,6 +141,22 @@ def create(
             show_default=False,
         ),
     ] = False,
+    newrelic: Annotated[
+        bool,
+        typer.Option(
+            "--newrelic/--no-newrelic",
+            help="Enable NewRelic APM monitoring for the web process.",
+            show_default=False,
+        ),
+    ] = False,
+    newrelic_license_key: Annotated[
+        str | None,
+        typer.Option(
+            "--newrelic-license-key",
+            help="NewRelic ingest license key. Required when --newrelic is set.",
+            show_default=False,
+        ),
+    ] = None,
 ):
     """
     Create a new bench with apps.
@@ -153,6 +169,9 @@ def create(
     fm_config: FMConfigManager = ctx.obj["fm_config_manager"]
 
     benchname = validate_sitename(benchname)
+
+    if newrelic and not newrelic_license_key:
+        raise typer.BadParameter("--newrelic-license-key is required when --newrelic is set.")
 
     all_domains = {benchname}
     if alias_domains:
@@ -221,6 +240,8 @@ def create(
         admin_tools_username=None,
         admin_tools_password=None,
         restart_policy=restart,
+        newrelic_enabled=newrelic,
+        newrelic_license_key=newrelic_license_key,
     )
 
     if apps:

--- a/frappe_manager/commands/update.py
+++ b/frappe_manager/commands/update.py
@@ -197,6 +197,22 @@ def update(
             show_default=False,
         ),
     ] = False,
+    newrelic: Annotated[
+        bool | None,
+        typer.Option(
+            "--newrelic/--no-newrelic",
+            help="Enable or disable NewRelic APM monitoring for the web process.",
+            show_default=False,
+        ),
+    ] = None,
+    newrelic_license_key: Annotated[
+        str | None,
+        typer.Option(
+            "--newrelic-license-key",
+            help="NewRelic ingest license key.",
+            show_default=False,
+        ),
+    ] = None,
 ):
     """
     Update bench configuration and settings.
@@ -325,6 +341,24 @@ def update(
         if upload_limit:
             output.change_head(f"Updating upload size limit to {upload_limit}")
             bench.update_upload_limit(upload_limit)
+
+        if newrelic is not None or newrelic_license_key is not None:
+            if newrelic is True and not (newrelic_license_key or bench.bench_config.newrelic_license_key):
+                raise typer.BadParameter("--newrelic-license-key is required when enabling NewRelic.")
+
+            if newrelic is not None:
+                bench.bench_config.newrelic_enabled = newrelic
+
+            if newrelic_license_key is not None:
+                bench.bench_config.newrelic_license_key = newrelic_license_key
+
+            bench.generate_compose(bench.bench_config.export_to_compose_inputs())
+            bench.save_bench_config()
+            bench_config_save = False
+
+            output.change_head("Restarting frappe container to apply NewRelic changes")
+            bench.docker_client.compose.up(services=["frappe"], detach=True, force_recreate=True)
+            output.print("NewRelic configuration updated")
 
         if python_version or node_version:
             frappe_app_path = bench.path / "workspace" / "frappe-bench" / "apps" / "frappe"

--- a/frappe_manager/site_manager/bench_config.py
+++ b/frappe_manager/site_manager/bench_config.py
@@ -968,6 +968,10 @@ class BenchConfig(BaseModel):
         description="Migration state tracking (managed by migration system)",
     )
 
+    # NewRelic APM
+    newrelic_enabled: bool = Field(False, description="Enable NewRelic APM monitoring for the web process")
+    newrelic_license_key: str | None = Field(None, description="NewRelic license key (ingest key)")
+
     @field_validator("restart_policy", mode="before")
     @classmethod
     def set_default_restart_policy(cls, v, info):
@@ -1188,6 +1192,8 @@ class BenchConfig(BaseModel):
             "db_name": data.get("db_name"),
             "restart_policy": data.get("restart_policy", None),
             "migration_state": migration_state_obj,
+            "newrelic_enabled": data.get("newrelic_enabled", False),
+            "newrelic_license_key": data.get("newrelic_license_key", None),
         }
 
         bench_config_instance = cls(**input_data)
@@ -1228,6 +1234,11 @@ class BenchConfig(BaseModel):
                 "USERID": self.userid,
                 "USERGROUP": self.usergroup,
                 "SERVICE_NAME": "frappe",
+                **(
+                    {"NEWRELIC_ENABLED": "true", "NEWRELIC_LICENSE_KEY": self.newrelic_license_key}
+                    if self.newrelic_enabled and self.newrelic_license_key
+                    else {}
+                ),
             },
             "nginx": {
                 "SITE_MAPPINGS": json.dumps(self.get_site_mappings()),

--- a/frappe_manager/site_manager/modules/bench_app.py
+++ b/frappe_manager/site_manager/modules/bench_app.py
@@ -543,17 +543,6 @@ fi
 
         return apps_config
 
-    def _create_venv(self) -> None:
-        venv_path = "/workspace/frappe-bench/env"
-        create_venv_cmd = f"uv venv {venv_path} --python 3.12"
-
-        try:
-            self._container_run(create_venv_cmd, raise_exception_obj=None)
-        except Exception as e:
-            self.logger.warning(f"Failed to create venv with UV: {e}, trying python -m venv")
-            create_venv_cmd = f"python3.12 -m venv {venv_path}"
-            self._container_run(create_venv_cmd, raise_exception_obj=None)
-
     def _install_python_deps_with_uv(self, apps: list[AppConfig], use_uv: bool = True, use_run: bool = False) -> None:
         """
         Install Python dependencies using UV (much faster than pip).
@@ -585,19 +574,43 @@ fi
 
                 return
             except Exception as uv_error:
-                self.logger.debug(f"UV installation failed, attempting pip fallback: {uv_error}")
+                self.logger.debug(f"UV installation failed, attempting uv pip fallback: {uv_error}")
 
                 try:
-                    install_cmd = " ".join(self.bench_cli_cmd + ["setup", "requirements", "--python"])
-                    self._container_run(install_cmd, use_run=use_run)
-                    self.output.warning("UV installation failed, successfully fell back to pip")
+                    for app in apps:
+                        fallback_cmd = " ".join(
+                            [
+                                "uv",
+                                "pip",
+                                "install",
+                                "--python",
+                                "/workspace/frappe-bench/env/bin/python",
+                                "--no-cache-dir",
+                                "-e",
+                                f"apps/{app.name}",
+                            ]
+                        )
+                        self._container_run(fallback_cmd, use_run=use_run)
+                    self.output.warning("UV installation failed on first attempt, succeeded on retry")
                 except Exception:
                     raise
 
                 return
 
-        install_cmd = " ".join(self.bench_cli_cmd + ["setup", "requirements", "--python"])
-        self._container_run(install_cmd, use_run=use_run)
+        for app in apps:
+            install_cmd = " ".join(
+                [
+                    "uv",
+                    "pip",
+                    "install",
+                    "--python",
+                    "/workspace/frappe-bench/env/bin/python",
+                    "--no-cache-dir",
+                    "-e",
+                    f"apps/{app.name}",
+                ]
+            )
+            self._container_run(install_cmd, use_run=use_run)
 
     def _install_node_deps(self, use_run: bool = False) -> None:
         """Install Node.js dependencies for all apps."""

--- a/frappe_manager/site_manager/modules/bench_orchestrator.py
+++ b/frappe_manager/site_manager/modules/bench_orchestrator.py
@@ -183,7 +183,7 @@ class BenchOrchestrator:
         self._detect_python_node_versions()
 
         if bench.bench_config.python_version or bench.bench_config.node_version:
-            bench.app_manager.setup_python_and_node_environments(use_run=True)
+            bench.app_manager.setup_python_and_node_environments(use_run=True, recreate_python_env=True)
 
         self.output.change_head("Installing dependencies for all apps")
         bench.app_manager.install_apps(

--- a/frappe_manager/site_manager/modules/bench_supervisor.py
+++ b/frappe_manager/site_manager/modules/bench_supervisor.py
@@ -185,7 +185,7 @@ class BenchSupervisor:
     def _can_enable_multi_queue_consumption(self, bench_path) -> bool:
         return True
 
-    def generate_supervisor_config(self, bench_path, user="frappe", skip_redis=True) -> str:
+    def generate_supervisor_config(self, bench_path, user="frappe", skip_redis=True) -> tuple[str, dict]:
         from pathlib import Path
 
         host_bench_dir = Path(bench_path).resolve() / "workspace" / "frappe-bench"
@@ -221,7 +221,7 @@ class BenchSupervisor:
         }
 
         template_path = get_template_path("supervisor.conf.tmpl")
-        return Template(template_path.read_text()).render(**context)
+        return Template(template_path.read_text()).render(**context), context
 
     def setup_supervisor(self, bench_path, force: bool = False, use_run: bool = False) -> None:
         import configparser
@@ -239,7 +239,7 @@ class BenchSupervisor:
 
         self.output.change_head("Configuring supervisor configs")
         try:
-            rendered = self.generate_supervisor_config(bench_path)
+            rendered, context = self.generate_supervisor_config(bench_path)
         except Exception as e:
             raise BenchOperationException(self.bench_name, f"Failed to configure supervisor: {e}")
 
@@ -247,6 +247,7 @@ class BenchSupervisor:
         parsed = configparser.ConfigParser(allow_no_value=True, strict=False, interpolation=None)
         parsed.read_string(rendered)
         self._write_split_configs(parsed, config_dir)
+        self._write_gunicorn_wrapper(config_dir, context)
         self.output.print("Configured supervisor configs")
 
     def _write_split_configs(self, config, config_dir) -> None:
@@ -275,3 +276,27 @@ class BenchSupervisor:
             section_config.write(buf)
             Path(config_dir / file_name).write_text(buf.getvalue())
             self.logger.info(f"Split supervisor conf {section_name} => {file_name}")
+
+    def _write_gunicorn_wrapper(self, config_dir, context: dict) -> None:
+        from pathlib import Path
+
+        gunicorn_args = (
+            f"-b 0.0.0.0:{context['webserver_port']}"
+            f" -w {context['gunicorn_workers']}"
+            f" --max-requests {context['gunicorn_max_requests']}"
+            f" --max-requests-jitter {context['gunicorn_max_requests_jitter']}"
+            f" -t {context['http_timeout']}"
+            f" --graceful-timeout 30"
+            f" frappe.app:application --preload"
+        )
+
+        template_path = get_template_path("fm-web-server.sh.tmpl")
+        script = Template(template_path.read_text()).render(
+            bench_dir=context["bench_dir"],
+            gunicorn_args=gunicorn_args,
+        )
+
+        wrapper_path = Path(config_dir) / "fm-web-server.sh"
+        wrapper_path.write_text(script)
+        wrapper_path.chmod(0o755)
+        self.logger.info("Generated gunicorn.sh wrapper")

--- a/frappe_manager/templates/fm-web-server.sh.tmpl
+++ b/frappe_manager/templates/fm-web-server.sh.tmpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+BENCH_DIR="{{ bench_dir }}"
+GUNICORN_ARGS="{{ gunicorn_args }}"
+
+if [[ "${NEWRELIC_ENABLED:-}" == "true" && -n "${NEWRELIC_LICENSE_KEY:-}" ]]; then
+    "$BENCH_DIR/env/bin/python" -c "import newrelic" 2>/dev/null || \
+        /usr/local/bin/uv pip install --quiet newrelic --python "$BENCH_DIR/env/bin/python"
+    "$BENCH_DIR/env/bin/newrelic-admin" generate-config \
+        "$NEWRELIC_LICENSE_KEY" \
+        "$BENCH_DIR/config/newrelic.ini"
+    export NEW_RELIC_CONFIG_FILE="$BENCH_DIR/config/newrelic.ini"
+    exec "$BENCH_DIR/env/bin/newrelic-admin" run-program \
+        "$BENCH_DIR/env/bin/gunicorn" $GUNICORN_ARGS
+else
+    exec "$BENCH_DIR/env/bin/gunicorn" $GUNICORN_ARGS
+fi

--- a/frappe_manager/templates/supervisor.conf.tmpl
+++ b/frappe_manager/templates/supervisor.conf.tmpl
@@ -4,7 +4,7 @@
 
 ; graceful timeout should always be lower than stopwaitsecs to avoid orphan gunicorn workers.
 [program:{{ bench_name }}-frappe-web]
-command={{ bench_dir }}/env/bin/gunicorn -b 0.0.0.0:{{ webserver_port }} -w {{ gunicorn_workers }} --max-requests {{ gunicorn_max_requests }} --max-requests-jitter {{ gunicorn_max_requests_jitter }} -t {{ http_timeout }} --graceful-timeout 30 frappe.app:application --preload
+command=/bin/bash {{ bench_dir }}/config/fm-web-server.sh
 priority=4
 autostart=true
 autorestart=true


### PR DESCRIPTION


**NewRelic APM Integration:**

* Added `--newrelic/--no-newrelic` and `--newrelic-license-key` options to the `create` and `update` commands, allowing users to enable NewRelic monitoring and provide the required license key. The commands validate that the license key is provided when enabling NewRelic. (`frappe_manager/commands/create.py` [[1]](diffhunk://#diff-685c07a4a7bf107ebd9290d674db5928218eed10ac9fb639eef73cd55f68dad7R144-R159) [[2]](diffhunk://#diff-685c07a4a7bf107ebd9290d674db5928218eed10ac9fb639eef73cd55f68dad7R173-R175) [[3]](diffhunk://#diff-685c07a4a7bf107ebd9290d674db5928218eed10ac9fb639eef73cd55f68dad7R243-R244); `frappe_manager/commands/update.py` [[4]](diffhunk://#diff-9d01e7c68708f99a2a167c511f113a82da6eba3c8ce24c6ce3639491294ec84fR200-R215) [[5]](diffhunk://#diff-9d01e7c68708f99a2a167c511f113a82da6eba3c8ce24c6ce3639491294ec84fR345-R362)
* Extended `BenchConfig` to persist NewRelic configuration and ensured import/export of these settings from/to TOML and Docker Compose inputs. (`frappe_manager/site_manager/bench_config.py` [[1]](diffhunk://#diff-d6bd48a65b2dbe6e0769480b2009076454290d78f6c089117d49dc57267be8cfR971-R974) [[2]](diffhunk://#diff-d6bd48a65b2dbe6e0769480b2009076454290d78f6c089117d49dc57267be8cfR1195-R1196) [[3]](diffhunk://#diff-d6bd48a65b2dbe6e0769480b2009076454290d78f6c089117d49dc57267be8cfR1237-R1241)
* Added a new template script (`fm-web-server.sh.tmpl`) that conditionally installs and configures NewRelic at runtime, and updated the supervisor config to use this wrapper instead of calling Gunicorn directly. (`frappe_manager/templates/fm-web-server.sh.tmpl` [[1]](diffhunk://#diff-5e1490043ed5ab52d0d44703ac07ac33e2941369624947b6c86add29cea7b4c8R1-R16) `frappe_manager/templates/supervisor.conf.tmpl` [[2]](diffhunk://#diff-d748dd1148688d683759ab9c35fa3ba441268c3abdfb311dfe2409276bec782aL7-R7)
* Modified supervisor setup to generate and deploy the new Gunicorn wrapper script, passing relevant context. (`frappe_manager/site_manager/modules/bench_supervisor.py` [[1]](diffhunk://#diff-98946f9f5303d2c69d80b93dbf2b96c025d442da8aa66a97bc9b43c16963cdb4L188-R188) [[2]](diffhunk://#diff-98946f9f5303d2c69d80b93dbf2b96c025d442da8aa66a97bc9b43c16963cdb4L224-R224) [[3]](diffhunk://#diff-98946f9f5303d2c69d80b93dbf2b96c025d442da8aa66a97bc9b43c16963cdb4L242-R250) [[4]](diffhunk://#diff-98946f9f5303d2c69d80b93dbf2b96c025d442da8aa66a97bc9b43c16963cdb4R279-R302)

**Dependency Installation Improvements:**

* Removed the `_create_venv` method and improved the Python dependency installation logic to better handle failures and retries using `uv pip install` for each app individually, with clearer fallback behavior. (`frappe_manager/site_manager/modules/bench_app.py` [[1]](diffhunk://#diff-20f0f51790ffb5ceaf88ecd5db783539e02687c20c6d096767f8b91705d333ffL546-L556) [[2]](diffhunk://#diff-20f0f51790ffb5ceaf88ecd5db783539e02687c20c6d096767f8b91705d333ffL588-R612)
* Ensured the Python environment is recreated when initializing the bench if the Python or Node.js version is specified. (`frappe_manager/site_manager/modules/bench_orchestrator.py` [frappe_manager/site_manager/modules/bench_orchestrator.pyL186-R186](diffhunk://#diff-7d240e3f930ab6fecf38f11ceb39b0b8b1a2e9ef2c210fcf79af8a88576fff07L186-R186))