### PR TITLE
Enhance service profile handling and availability checks

### DIFF
--- a/frappe_manager/docker/compose_file.py
+++ b/frappe_manager/docker/compose_file.py
@@ -117,8 +117,13 @@ class ComposeFile:
         """
         Returns a list of services defined in the Compose file.
 
+        Args:
+            exclude_disabled: When True, services marked as disabled via the
+                ``disabled`` profile are excluded from the returned list.
+
         Returns:
-            list: A list of service names.
+            list: A list of service names. May be filtered if ``exclude_disabled``
+                is True.
         """
         services = list(self.yml["services"].keys())
         if exclude_disabled:
@@ -1176,9 +1181,14 @@ class ComposeFile:
 
     def is_service_profile_disabled(self, service: str) -> bool:
         try:
-            profiles = self.yml["services"][service].get("profiles", [])
+            service_definition = self.yml["services"][service]
+            if not hasattr(service_definition, "get"):
+                return False
+            profiles = service_definition.get("profiles", [])
+            if isinstance(profiles, str):
+                return profiles == "disabled"
             return "disabled" in profiles
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, AttributeError):
             return False
 
     @classmethod

--- a/frappe_manager/docker/compose_file.py
+++ b/frappe_manager/docker/compose_file.py
@@ -79,15 +79,12 @@ class ComposeFile:
             dict: The contents of the template file as a YAML object.
         """
         template_path: Path = get_template_path(self.template_name, self.template_dir)
-        
+
         # Render Jinja2 template with dynamic image tags
         template = Template(template_path.read_text())
         image_tag = get_docker_image_tag()
-        rendered_template = template.render(
-            frappe_image_tag=image_tag,
-            nginx_image_tag=image_tag
-        )
-        
+        rendered_template = template.render(frappe_image_tag=image_tag, nginx_image_tag=image_tag)
+
         # Parse rendered YAML
         yml = yaml.load(rendered_template)
         return yml
@@ -116,14 +113,17 @@ class ComposeFile:
                 container_names[service] = self.yml["services"][service]["container_name"]
         return container_names
 
-    def get_services_list(self) -> list:
+    def get_services_list(self, exclude_disabled: bool = False) -> list:
         """
         Returns a list of services defined in the Compose file.
 
         Returns:
             list: A list of service names.
         """
-        return list(self.yml["services"].keys())
+        services = list(self.yml["services"].keys())
+        if exclude_disabled:
+            services = [s for s in services if not self.is_service_profile_disabled(s)]
+        return services
 
     def is_services_name_same_as_template(self):
         """
@@ -1137,15 +1137,12 @@ class ComposeFile:
             Parsed YAML dictionary
         """
         template_path: Path = get_template_path(template_name, template_dir)
-        
+
         # Render Jinja2 template with dynamic image tags
         template = Template(template_path.read_text())
         image_tag = get_docker_image_tag()
-        rendered_template = template.render(
-            frappe_image_tag=image_tag,
-            nginx_image_tag=image_tag
-        )
-        
+        rendered_template = template.render(frappe_image_tag=image_tag, nginx_image_tag=image_tag)
+
         # Parse rendered YAML
         yml = yaml.load(rendered_template)
         return yml
@@ -1176,6 +1173,13 @@ class ComposeFile:
                 images[service] = {"name": name, "tag": tag, "image": image}
 
         return images
+
+    def is_service_profile_disabled(self, service: str) -> bool:
+        try:
+            profiles = self.yml["services"][service].get("profiles", [])
+            return "disabled" in profiles
+        except (KeyError, TypeError):
+            return False
 
     @classmethod
     def get_template_services(

--- a/frappe_manager/services_manager/services.py
+++ b/frappe_manager/services_manager/services.py
@@ -80,7 +80,7 @@ class ServicesManager:
 
         if start:
             if not self.invoked_subcommand == "service":
-                services = self.compose_file_manager.get_services_list()
+                services = self.compose_file_manager.get_services_list(exclude_disabled=True)
                 containers = self.compose_file_manager.get_container_names().values()
                 all_statuses = self.docker_client.compose.get_all_services_status()
                 running_statuses = {
@@ -90,7 +90,7 @@ class ServicesManager:
 
                 if not all_running:
                     self.output.print(
-                        f"Started non running global services [blue]{', '.join(self.compose_file_manager.get_services_list())}[/blue].",
+                        f"Started non running global services [blue]{', '.join(services)}[/blue].",
                     )
                     self.docker_client.compose.up(services=[], detach=True, pull="missing")
 

--- a/frappe_manager/site_manager/modules/bench_site.py
+++ b/frappe_manager/site_manager/modules/bench_site.py
@@ -88,6 +88,11 @@ class BenchSiteManager:
             docker_client: Docker client for container operations
             bench_config: Bench configuration object
             services: Services manager providing database/Redis access
+            compose_file_manager: Optional ComposeFile instance for the bench's
+                docker-compose file. When provided, ``wait_for_required_services``
+                will skip health checks for any required services that are
+                marked as disabled in that compose file. Pass ``None`` (default)
+                to always perform all health checks regardless of service profiles.
             output_handler: Optional output handler for displaying information
         """
         self.logger = logger.child(component="site_manager")

--- a/frappe_manager/site_manager/modules/bench_site.py
+++ b/frappe_manager/site_manager/modules/bench_site.py
@@ -14,6 +14,7 @@ from typing import cast
 
 from frappe_manager import CLI_DEFAULT_DELIMETER
 from frappe_manager.docker import DockerClient, DockerException
+from frappe_manager.docker.compose_file import ComposeFile
 from frappe_manager.docker.subprocess_output import SubprocessOutput
 from frappe_manager.logger.contextual import ContextualLogger
 from frappe_manager.output_manager import OutputHandler
@@ -74,6 +75,7 @@ class BenchSiteManager:
         docker_client: DockerClient,
         bench_config: BenchConfig,
         services: ServicesManager,
+        compose_file_manager: ComposeFile | None = None,
         output_handler: OutputHandler | None = None,
     ):
         """
@@ -94,6 +96,7 @@ class BenchSiteManager:
         self.docker_client = docker_client
         self.bench_config = bench_config
         self.services = services
+        self.compose_file_manager = compose_file_manager
         self.output = output_handler or RichOutputHandler()
 
         self.frappe_bench_dir: Path = bench_path / "workspace" / "frappe-bench"
@@ -138,18 +141,26 @@ class BenchSiteManager:
         """
         self.output.change_head("Checking if required services are available")
 
-        # Build required services map
         cache_host, cache_port = get_redis_cache_addr(self.bench_config.container_name_prefix)
         queue_host, queue_port = get_redis_queue_addr(self.bench_config.container_name_prefix)
-        required_services = {
-            self.services.database_manager.database_server_info.host: self.services.database_manager.database_server_info.port,
-            cache_host: cache_port,
-            queue_host: queue_port,
-        }
+        candidates = [
+            (
+                None,
+                self.services.database_manager.database_server_info.host,
+                self.services.database_manager.database_server_info.port,
+            ),
+            ("redis-cache", cache_host, cache_port),
+            ("redis-queue", queue_host, queue_port),
+        ]
 
-        # Check each service
-        for service, port in required_services.items():
-            output: SubprocessOutput = self._wait_for_service(host=service, port=port, timeout=timeout)
+        for compose_service, host, port in candidates:
+            if (
+                compose_service
+                and self.compose_file_manager
+                and self.compose_file_manager.is_service_profile_disabled(compose_service)
+            ):
+                continue
+            output: SubprocessOutput = self._wait_for_service(host=host, port=port, timeout=timeout)
             if output.combined:
                 command_output = output.combined[-1].replace("wait-for-it: ", "")
                 service_name = command_output.split(" ")[0]

--- a/frappe_manager/site_manager/modules/bench_site.py
+++ b/frappe_manager/site_manager/modules/bench_site.py
@@ -141,24 +141,18 @@ class BenchSiteManager:
         """
         self.output.change_head("Checking if required services are available")
 
+        db_info = self.services.database_manager.database_server_info
         cache_host, cache_port = get_redis_cache_addr(self.bench_config.container_name_prefix)
         queue_host, queue_port = get_redis_queue_addr(self.bench_config.container_name_prefix)
+
         candidates = [
-            (
-                None,
-                self.services.database_manager.database_server_info.host,
-                self.services.database_manager.database_server_info.port,
-            ),
-            ("redis-cache", cache_host, cache_port),
-            ("redis-queue", queue_host, queue_port),
+            (self.services.compose_file_manager, db_info.host, db_info.host, db_info.port),
+            (self.compose_file_manager, "redis-cache", cache_host, cache_port),
+            (self.compose_file_manager, "redis-queue", queue_host, queue_port),
         ]
 
-        for compose_service, host, port in candidates:
-            if (
-                compose_service
-                and self.compose_file_manager
-                and self.compose_file_manager.is_service_profile_disabled(compose_service)
-            ):
+        for cfm, compose_service, host, port in candidates:
+            if cfm and cfm.is_service_profile_disabled(compose_service):
                 continue
             output: SubprocessOutput = self._wait_for_service(host=host, port=port, timeout=timeout)
             if output.combined:

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -168,6 +168,7 @@ class Bench:
             docker_client=docker_client,
             bench_config=bench_config,
             services=services,
+            compose_file_manager=compose_file_manager,
             output_handler=self.output,
         )
 

--- a/tests/unit/docker/test_compose_file.py
+++ b/tests/unit/docker/test_compose_file.py
@@ -769,3 +769,59 @@ services:
         assert callable(ComposeFile.load_template_yml)
         assert callable(ComposeFile.get_template_images)
         assert callable(ComposeFile.get_template_services)
+
+
+class TestServiceProfileDisabled:
+    """Tests for is_service_profile_disabled and get_services_list(exclude_disabled=True)."""
+
+    def _make_cf(self, temp_compose_yml, yml_content):
+        with patch("builtins.open", mock_open()):
+            with patch("frappe_manager.docker.compose_file.yaml.load", return_value=yml_content):
+                return ComposeFile(temp_compose_yml, auto_save=False)
+
+    def test_disabled_profile_as_list(self, temp_compose_yml, sample_yml_content):
+        sample_yml_content["services"]["frappe"]["profiles"] = ["disabled"]
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        assert cf.is_service_profile_disabled("frappe") is True
+
+    def test_disabled_profile_as_string(self, temp_compose_yml, sample_yml_content):
+        sample_yml_content["services"]["frappe"]["profiles"] = "disabled"
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        assert cf.is_service_profile_disabled("frappe") is True
+
+    def test_non_disabled_profile_string_no_false_positive(self, temp_compose_yml, sample_yml_content):
+        sample_yml_content["services"]["frappe"]["profiles"] = "notdisabled"
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        assert cf.is_service_profile_disabled("frappe") is False
+
+    def test_disabled_in_list_with_other_profiles(self, temp_compose_yml, sample_yml_content):
+        sample_yml_content["services"]["frappe"]["profiles"] = ["web", "disabled"]
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        assert cf.is_service_profile_disabled("frappe") is True
+
+    def test_no_profiles_key(self, temp_compose_yml, sample_yml_content):
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        assert cf.is_service_profile_disabled("frappe") is False
+
+    def test_nonexistent_service(self, temp_compose_yml, sample_yml_content):
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        assert cf.is_service_profile_disabled("nonexistent") is False
+
+    def test_get_services_list_exclude_disabled_filters_service(self, temp_compose_yml, sample_yml_content):
+        sample_yml_content["services"]["frappe"]["profiles"] = ["disabled"]
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        services = cf.get_services_list(exclude_disabled=True)
+        assert "frappe" not in services
+        assert "nginx" in services
+
+    def test_get_services_list_exclude_disabled_false_returns_all(self, temp_compose_yml, sample_yml_content):
+        sample_yml_content["services"]["frappe"]["profiles"] = ["disabled"]
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        services = cf.get_services_list(exclude_disabled=False)
+        assert "frappe" in services
+        assert "nginx" in services
+
+    def test_get_services_list_no_disabled_services(self, temp_compose_yml, sample_yml_content):
+        cf = self._make_cf(temp_compose_yml, sample_yml_content)
+        services = cf.get_services_list(exclude_disabled=True)
+        assert services == list(sample_yml_content["services"].keys())


### PR DESCRIPTION
**Service management improvements:**

* Added a new method `is_service_profile_disabled` to `ComposeFile` to determine if a service is marked as disabled via its profiles.
* Updated `get_services_list` in `ComposeFile` to accept an `exclude_disabled` parameter, allowing callers to filter out disabled services.
* Updated service startup checks in `entrypoint_checks` to use the new `exclude_disabled=True` option, ensuring only enabled services are started and reported. [[1]](diffhunk://#diff-4f1126f33fb087d4bb4bea404dc0ef02a5dcd9627edfb05ac5cfa20265ce180dL83-R83) [[2]](diffhunk://#diff-4f1126f33fb087d4bb4bea404dc0ef02a5dcd9627edfb05ac5cfa20265ce180dL93-R93)

**Site management and dependency injection:**

* Updated `BenchSite` and related site management logic to accept and use a `compose_file_manager` instance, improving flexibility and testability. [[1]](diffhunk://#diff-e56aa2ca3c758058e38f541580b808b8ed595bf2a1929ceb8b99dbf63a90835fR78) [[2]](diffhunk://#diff-e56aa2ca3c758058e38f541580b808b8ed595bf2a1929ceb8b99dbf63a90835fR99) [[3]](diffhunk://#diff-1ef03bc1fddd777e30fe06d8337f0580472af6d656cf46368de3992870043f9cR171)
* Enhanced the `wait_for_required_services` method to skip health checks for required services that are disabled in the Compose file, preventing unnecessary waits or failures for intentionally disabled services.

**Minor refactoring:**

* Simplified Jinja2 template rendering calls in `ComposeFile` for improved readability. [[1]](diffhunk://#diff-f0dbf5a2891d8e4a33fc1e0aa2c1b7d7fb2c3cd8f1308d45046a8a1e54df4559L86-R86) [[2]](diffhunk://#diff-f0dbf5a2891d8e4a33fc1e0aa2c1b7d7fb2c3cd8f1308d45046a8a1e54df4559L1144-R1144)
* Added missing import for `ComposeFile` in `bench_site.py`.