### PR TITLE
Bump nginx-proxy version 

### DIFF
--- a/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
@@ -583,6 +583,15 @@ class MigrationV0190(MigrationBase):
         self.output.print(f"All {self.version.version_string()} images pulled successfully")
         self.logger.info("[migrate_services] Docker image pull completed successfully")
 
+        # Recreate global-nginx-proxy to pick up the updated image tag.
+        self.output.print("Restarting global-nginx-proxy with new image...")
+        self.services_manager.docker_client.compose.up(
+            services=["global-nginx-proxy"],
+            force_recreate=True,
+            detach=True,
+        )
+        self.logger.info("[migrate_services] global-nginx-proxy recreated with new image")
+
     def undo_services_migrate(self):
         """No global services rollback needed."""
         self.output.print(f"No services rollback needed for {self.version.version_string()}")

--- a/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
@@ -533,14 +533,41 @@ class MigrationV0190(MigrationBase):
 
         self.output.print("✓ Images ready", emoji_code="✅")
 
+    def _update_global_nginx_proxy_image(self):
+        """Update global-nginx-proxy image from jwilder/nginx-proxy:1.6 to 1.11."""
+        cf = self.services_manager.compose_file_manager
+
+        if not cf.exists():
+            self.logger.debug("[_update_global_nginx_proxy_image] Services compose not found, skipping")
+            return
+
+        services = cf.yml.get("services")
+        if not services:
+            return
+
+        nginx_service = services.get("global-nginx-proxy")
+        if not nginx_service or "image" not in nginx_service:
+            return
+
+        old_image = nginx_service["image"]
+        new_image = "jwilder/nginx-proxy:1.11"
+
+        if old_image != new_image:
+            nginx_service["image"] = new_image
+            cf.write_to_file()
+            self.output.print(f"Updated global-nginx-proxy image: {old_image} → {new_image}")
+            self.logger.info(f"[_update_global_nginx_proxy_image] Updated: {old_image} → {new_image}")
+
     def migrate_services(self):
         """
-        Pull current version Docker images (system-level infrastructure).
+        Pull current version Docker images and update global-nginx-proxy image tag.
 
         Images are shared resources across all benches - must be pulled
         at system level before any bench can use them.
         """
         from frappe_manager.utils.site import pull_docker_images
+
+        self._update_global_nginx_proxy_image()
 
         self.logger.info(f"[migrate_services] Starting Docker image pull for {self.version.version_string()}")
 

--- a/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
@@ -585,7 +585,7 @@ class MigrationV0190(MigrationBase):
 
         # Recreate global-nginx-proxy to pick up the updated image tag.
         self.output.print("Restarting global-nginx-proxy with new image...")
-        self.services_manager.docker_client.compose.up(
+        self.services_manager.compose.up(
             services=["global-nginx-proxy"],
             force_recreate=True,
             detach=True,

--- a/frappe_manager/templates/docker-compose.services.osx.tmpl
+++ b/frappe_manager/templates/docker-compose.services.osx.tmpl
@@ -27,7 +27,7 @@ services:
   global-nginx-proxy:
     container_name: fm_global-nginx-proxy
     user: REPLACE_WITH_CURRENT_USER:REPLACE_WITH_CURRENT_USER_GROUP
-    image: jwilder/nginx-proxy:1.6
+    image: jwilder/nginx-proxy:1.11
     environment:
       ACME_HTTP_CHALLENGE_LOCATION: false
     ports:

--- a/frappe_manager/templates/docker-compose.services.tmpl
+++ b/frappe_manager/templates/docker-compose.services.tmpl
@@ -27,7 +27,7 @@ services:
   global-nginx-proxy:
     container_name: fm_global-nginx-proxy
     user: REPLACE_WITH_CURRENT_USER:REPLACE_WITH_CURRENT_USER_GROUP
-    image: jwilder/nginx-proxy:1.6
+    image: jwilder/nginx-proxy:1.11
     environment:
       ACME_HTTP_CHALLENGE_LOCATION: false
     ports:

--- a/scripts/migrate-test.sh
+++ b/scripts/migrate-test.sh
@@ -391,6 +391,18 @@ cmd_status() {
     echo "  ── docker-compose.workers.yml ───────────────────────────────"
     ssh_cmd "test -f \"$DCW\" && (echo '  File: $DCW (exists)'; grep -n 'image:' \"$DCW\" 2>/dev/null | sed 's/^/    /') || echo '  File: $DCW (NOT FOUND)'"
 
+    # ── Services docker-compose ───────────────────────────────────────────
+    local SDIR="$FM_DIR/services"
+    local SDCFG="$SDIR/docker-compose.yml"
+    echo ""
+    echo "  ── services/docker-compose.yml ──────────────────────────────"
+    if ssh_cmd "test -f \"$SDCFG\"" 2>/dev/null; then
+        echo "  File: $SDCFG (exists)"
+        ssh_cmd "grep -n 'image:' \"$SDCFG\" 2>/dev/null | sed 's/^/    /'"
+    else
+        echo "  File: $SDCFG (NOT FOUND)"
+    fi
+
     # ── bench_config.toml ────────────────────────────────────────────────
     echo ""
     echo "  ── bench_config.toml ────────────────────────────────────────"


### PR DESCRIPTION
This pull request updates the default Docker image version for the `global-nginx-proxy` service from `jwilder/nginx-proxy:1.6` to `1.11` across both new deployments and existing installations. It introduces a migration method to update the image version in existing `docker-compose` files and ensures the new version is used going forward.

**Docker image update for global-nginx-proxy:**

* Added a migration method `_update_global_nginx_proxy_image` in `migrate_0_19_0.py` to automatically update the `global-nginx-proxy` image from `jwilder/nginx-proxy:1.6` to `1.11` in existing `docker-compose` files during migration.
* Updated the default `global-nginx-proxy` image to `jwilder/nginx-proxy:1.11` in both `docker-compose.services.tmpl` and `docker-compose.services.osx.tmpl` templates, ensuring new setups use the latest image. [[1]](diffhunk://#diff-9d44aff01c5c84c2ba0431346751fac6af2487da8afdebcc5dd5a3eb356f7ee0L30-R30) [[2]](diffhunk://#diff-50be6b37c71a06f4550729448a3de7fdb90e76beea4af737901b13af5c6a739dL30-R30)