### PR TITLE
feat(restart): graceful gunicorn reload via supervisorctl signal HUP

### DIFF
--- a/Docker/frappe/fmx/fmx/commands/restart.py
+++ b/Docker/frappe/fmx/fmx/commands/restart.py
@@ -22,13 +22,70 @@ from fmx.cli import ServiceNameEnumFactory, execute_parallel_command, get_servic
 from fmx.supervisor.api import (
     start_service as util_start_service,
     restart_service as util_restart_service,
+    signal_service as util_signal_service,
 )
 from fmx.commands._rq_helpers import suspend_rq_workers, resume_rq_workers, run_with_optional_rq_drain
 
 
 command_name = "restart"
 
+# Signal used by the --graceful path. SIGHUP triggers an in-place worker reload in
+# gunicorn (the master never closes its listening socket, so upstream proxies do not
+# observe a connection-refused window across the reload).
+GRACEFUL_RELOAD_SIGNAL = "HUP"
+
 ServiceNamesEnum = ServiceNameEnumFactory()
+
+
+def _graceful_reload_service(
+    service_name: str,
+    progress_callback=None,
+    **_extra_kwargs,
+):
+    """Signal-based in-place reload of every process in a service.
+
+    Designed to plug into ``execute_parallel_command`` in the same slot as
+    ``util_restart_service``. Accepts (and ignores) the restart-specific kwargs
+    (``wait``, ``wait_workers``, ``worker_kill_timeout``, ``worker_kill_poll``,
+    ``verbose``) so the caller signature is interchangeable. Discovers the current
+    process list for the service and dispatches ``GRACEFUL_RELOAD_SIGNAL`` to each
+    one via the supervisor XML-RPC API.
+
+    For the frappe web service this hands SIGHUP to the gunicorn master, which forks
+    fresh workers using the still-open listening socket and only then retires the old
+    workers — eliminating the brief connect-refused window of a stop/start cycle.
+    """
+    # Imported here to avoid a circular import at module load time.
+    from fmx.supervisor.connection import check_supervisord_connection
+
+    try:
+        conn = check_supervisord_connection(service_name)
+        all_info = conn.supervisor.getAllProcessInfo() or []
+    except Exception as e:
+        return {"signalled": [], "failed": [service_name], "error": str(e)}
+
+    process_names = [info["name"] for info in all_info]
+    if not process_names:
+        return {"signalled": [], "failed": []}
+
+    ok = util_signal_service(service_name, GRACEFUL_RELOAD_SIGNAL, process_name_list=process_names)
+
+    if progress_callback:
+        for name in process_names:
+            info = next((i for i in all_info if i.get("name") == name), {})
+            pid = info.get("pid") or 0
+            progress_callback(
+                service_name,
+                name,
+                "reload",
+                pid,
+                f"signal {GRACEFUL_RELOAD_SIGNAL}" if ok else "failed",
+                0.0,
+            )
+
+    if ok:
+        return {"signalled": process_names, "failed": []}
+    return {"signalled": [], "failed": process_names}
 
 
 def set_maintenance_mode(display: DisplayManager, enabled: bool) -> None:
@@ -418,6 +475,17 @@ def _handle_migrate_failure(
         "before they can honour the shutdown signal. Only applies to the non-drain path."
     ),
 )
+@_example(
+    "Graceful in-place reload (no upstream connection-refused window)",
+    "frappe --graceful",
+    detail=(
+        "Signals the gunicorn master with SIGHUP so it forks fresh workers using the "
+        "still-open listening socket and then retires the old workers. The master never "
+        "closes the listener, so an upstream proxy observes no connect-refused window. "
+        "Recommended for production deploys of the web service. Pair with --no-drain-workers "
+        "(or just target only `frappe`) if you do not need to drain RQ workers."
+    ),
+)
 def command(
     ctx: typer.Context,
     service_names: Annotated[
@@ -526,10 +594,28 @@ def command(
             help="Polling interval in seconds when waiting for a worker to exit after SIGUSR1.",
         ),
     ] = 3.0,
+    graceful: Annotated[
+        bool,
+        typer.Option(
+            "--graceful",
+            help=(
+                "In-place reload: signal each targeted process with SIGHUP via supervisord "
+                "instead of stop/start. Gunicorn handles SIGHUP by forking new workers using "
+                "the still-open listening socket and then retiring the old workers — the "
+                "master never closes the listener, so upstream proxies observe no "
+                "connection-refused window. Recommended for production deploys of the web "
+                "service. Mutually exclusive with --migrate (which performs a real restart)."
+            ),
+        ),
+    ] = False,
 ):
     """Restart services or specific processes."""
     display: DisplayManager = ctx.obj['display']
     debug: bool = ctx.obj.get('debug', False)
+
+    if graceful and migrate:
+        display.error("--graceful and --migrate are mutually exclusive.")
+        raise typer.Exit(code=1)
 
     valid_mm_values = {"drain", "migrate"}
     maintenance_set = set(maintenance_mode or [])
@@ -611,6 +697,16 @@ def command(
             if maintenance_enabled:
                 set_maintenance_mode(display, False)
                 maintenance_enabled = False
+
+            if graceful:
+                execute_parallel_command(
+                    services_to_target,
+                    _graceful_reload_service,
+                    action_verb="reloading",
+                    show_progress=True,
+                    wait=wait,
+                )
+                return
 
             execute_parallel_command(
                 services_to_target,

--- a/Docker/frappe/fmx/fmx/commands/restart.py
+++ b/Docker/frappe/fmx/fmx/commands/restart.py
@@ -88,6 +88,40 @@ def _graceful_reload_service(
     return {"signalled": [], "failed": process_names}
 
 
+def _print_graceful_reload_summary(display: DisplayManager, results: dict, elapsed: float) -> None:
+    """Print a success/failure summary for the ``--graceful`` reload path.
+
+    ``execute_parallel_command`` only formats summaries for the built-in
+    restart/start/stop handlers, so the graceful path has to surface its own
+    outcome. Mirrors the shape of ``_handle_restart_results`` in ``fmx.cli``.
+    """
+    total_services = len(results)
+    failed_services: list[str] = []
+    total_count = 0
+
+    for svc, result in results.items():
+        if isinstance(result, dict) and not result.get("error"):
+            total_count += len(result.get("signalled", []))
+            if result.get("failed"):
+                failed_services.append(svc)
+        else:
+            failed_services.append(svc)
+
+    elapsed_str = f"  [dim]({elapsed:.1f}s)[/dim]"
+
+    if not failed_services:
+        display.print(
+            f"\n[green]✔[/green]  Reloaded [bold]{total_services}[/bold] service(s) · "
+            f"[bold]{total_count}[/bold] process(es){elapsed_str}"
+        )
+    else:
+        ok = total_services - len(failed_services)
+        display.print(
+            f"\n[yellow]⚠[/yellow]  Reloaded [bold]{ok}/{total_services}[/bold] service(s){elapsed_str}"
+            f"  —  [red]{', '.join(failed_services)}[/red] failed"
+        )
+
+
 def set_maintenance_mode(display: DisplayManager, enabled: bool) -> None:
     """Enable or disable maintenance mode in common_site_config.json.
 
@@ -699,12 +733,17 @@ def command(
                 maintenance_enabled = False
 
             if graceful:
-                execute_parallel_command(
+                _reload_start = time.time()
+                reload_results = execute_parallel_command(
                     services_to_target,
                     _graceful_reload_service,
                     action_verb="reloading",
                     show_progress=True,
                     wait=wait,
+                    return_raw_results=True,
+                )
+                _print_graceful_reload_summary(
+                    display, reload_results or {}, elapsed=time.time() - _reload_start,
                 )
                 return
 

--- a/docs/commands/restart.md
+++ b/docs/commands/restart.md
@@ -23,6 +23,7 @@ $ fm restart BENCHNAME [OPTIONS]
 * `--container`: Restart entire Docker container(s). Stops and starts the container.
 * `--supervisor`: Restart supervisor processes inside container. Faster than container restart.
 * `--force`: Force restart: --supervisor uses stop+start (kills processes), --container uses timeout=0 (immediate kill).
+* `--graceful`: Reload the frappe (gunicorn) web container in place by sending SIGHUP via supervisorctl instead of stop/start. The gunicorn master keeps its listening socket open across the reload, so upstream proxies see no connection-refused window. Applies only to supervisor mode; ignored with --container. The socketio container is restarted normally (node has no graceful-reload signal). Mutually exclusive with --force.
 
 
 ## Examples
@@ -89,5 +90,15 @@ Restarts the nginx service for the bench, useful after configuration changes to 
 
 ```bash
 fm restart mybench --nginx
+```
+
+### Graceful web reload (no upstream connection-refused window)
+
+Delivers SIGHUP to the frappe (gunicorn) web container via supervisorctl instead of stop/start. The gunicorn master keeps its listening socket open while it spawns fresh workers and then retires the old ones, so an upstream proxy never observes a closed listener. The socketio container is restarted normally because node has no graceful-reload signal. Only affects supervisor mode; ignored when combined with --container.
+
+Caveat: the web container runs gunicorn with `--preload`, so SIGHUP recycles workers but does not re-import application code in the master. Use this flag when you want to restart workers without dropping the upstream listener (for example to release leaked memory or apply runtime config); use a full restart when you need new application code to take effect.
+
+```bash
+fm restart mybench --graceful
 ```
 

--- a/frappe_manager/commands/restart.py
+++ b/frappe_manager/commands/restart.py
@@ -57,6 +57,19 @@ from frappe_manager.utils.callbacks import sitename_callback, sites_autocompleti
     detail="Restarts the nginx service for the bench, useful after configuration changes to proxy or TLS.",
     benchname="mybench",
 )
+@example(
+    "Graceful web reload (no upstream connection-refused window)",
+    "{benchname} --graceful",
+    detail=(
+        "Delivers SIGHUP to the frappe (gunicorn) container via supervisorctl instead of "
+        "stop/start. The gunicorn master keeps its listening socket open while it spawns "
+        "fresh workers and then retires the old ones, so an upstream proxy never observes a "
+        "closed listener. The socketio container is restarted normally because node has no "
+        "graceful-reload signal. Only affects supervisor mode; ignored when combined with "
+        "--container."
+    ),
+    benchname="mybench",
+)
 def restart(
     ctx: typer.Context,
     benchname: Annotated[
@@ -104,6 +117,20 @@ def restart(
             help="Force restart: --supervisor uses stop+start (kills processes), --container uses timeout=0 (immediate kill).",
         ),
     ] = False,
+    graceful: Annotated[
+        bool,
+        typer.Option(
+            "--graceful",
+            help=(
+                "Reload the frappe (gunicorn) web container in place by sending SIGHUP via "
+                "supervisorctl instead of stop/start. The gunicorn master keeps its "
+                "listening socket open across the reload, so upstream proxies see no "
+                "connection-refused window. The socketio container is restarted normally "
+                "(node has no graceful-reload signal). Applies only to supervisor mode; "
+                "ignored with --container. Mutually exclusive with --force."
+            ),
+        ),
+    ] = False,
 ):
     """
     Restart bench services (web, workers, redis, nginx).
@@ -129,9 +156,22 @@ def restart(
     if use_container_restart and use_supervisor_restart:
         output.error("Cannot use both --container and --supervisor flags simultaneously", exception=typer.Exit(code=1))
 
+    if graceful and force:
+        output.error("Cannot use both --graceful and --force flags simultaneously", exception=typer.Exit(code=1))
+
+    if graceful and use_container_restart:
+        output.error(
+            "--graceful applies only to supervisor mode; cannot be combined with --container.",
+            exception=typer.Exit(code=1),
+        )
+
     with spinner(output, f"Restarting {benchname}"):
         if web:
-            bench.restart_web_containers_services(use_container_restart=use_container_restart, force=force)
+            bench.restart_web_containers_services(
+                use_container_restart=use_container_restart,
+                force=force,
+                graceful=graceful,
+            )
 
         if workers:
             bench.restart_workers_containers_services(use_container_restart=use_container_restart, force=force)

--- a/frappe_manager/commands/restart.py
+++ b/frappe_manager/commands/restart.py
@@ -160,10 +160,10 @@ def restart(
         output.error("Cannot use both --graceful and --force flags simultaneously", exception=typer.Exit(code=1))
 
     if graceful and use_container_restart:
-        output.error(
-            "--graceful applies only to supervisor mode; cannot be combined with --container.",
-            exception=typer.Exit(code=1),
+        output.warning(
+            "--graceful applies only to supervisor mode; ignoring it for --container restart."
         )
+        graceful = False
 
     with spinner(output, f"Restarting {benchname}"):
         if web:

--- a/frappe_manager/site_manager/modules/bench_supervisor.py
+++ b/frappe_manager/site_manager/modules/bench_supervisor.py
@@ -78,6 +78,7 @@ class BenchSupervisor:
         timeout: int = 30,
         interval: int = 1,
         force: bool = False,
+        graceful: bool = False,
     ) -> bool:
         """
         Restart a supervisor service.
@@ -88,6 +89,10 @@ class BenchSupervisor:
             timeout: Timeout in seconds (used for socket availability check after restart)
             interval: Check interval in seconds
             force: If True, stop then start processes (hard restart). If False, use restart command (graceful).
+            graceful: If True, deliver SIGHUP via ``supervisorctl signal HUP all`` instead of
+                stop/start. The gunicorn master keeps its listening socket open while it
+                forks fresh workers, eliminating the brief connection-refused window an
+                upstream proxy would otherwise observe. Mutually exclusive with ``force``.
 
         Returns:
             True if restarted successfully, False otherwise
@@ -110,7 +115,27 @@ class BenchSupervisor:
             self.output.display_error(text=f"Service [blue]{service}[/blue] not running.")
             return False
 
-        if force:
+        if graceful and force:
+            raise BenchOperationException(
+                self.bench_name,
+                message="--graceful and --force are mutually exclusive.",
+            )
+
+        if graceful:
+            signal_command = "supervisorctl -c /opt/user/supervisord.conf signal HUP all"
+            try:
+                docker_client_obj.compose.exec(
+                    service=service,
+                    user="frappe",
+                    command=signal_command,
+                    stream=False,
+                )
+            except DockerException as e:
+                raise BenchOperationException(
+                    self.bench_name,
+                    message=f"Failed to signal HUP for {service} service: {e!s}",
+                ) from e
+        elif force:
             stop_command = "supervisorctl -c /opt/user/supervisord.conf stop all"
             start_command = "supervisorctl -c /opt/user/supervisord.conf start all"
             try:

--- a/frappe_manager/site_manager/modules/bench_supervisor.py
+++ b/frappe_manager/site_manager/modules/bench_supervisor.py
@@ -88,11 +88,14 @@ class BenchSupervisor:
             docker_client_obj: Optional Docker client (uses self.docker_client if None)
             timeout: Timeout in seconds (used for socket availability check after restart)
             interval: Check interval in seconds
-            force: If True, stop then start processes (hard restart). If False, use restart command (graceful).
+            force: If True, stop then start processes (hard restart via
+                ``supervisorctl stop all`` followed by ``start all``).
             graceful: If True, deliver SIGHUP via ``supervisorctl signal HUP all`` instead of
                 stop/start. The gunicorn master keeps its listening socket open while it
                 forks fresh workers, eliminating the brief connection-refused window an
                 upstream proxy would otherwise observe. Mutually exclusive with ``force``.
+            (default, neither flag set): ``supervisorctl restart all`` -- supervisor
+                stops then re-spawns every process; the listening socket is briefly closed.
 
         Returns:
             True if restarted successfully, False otherwise

--- a/frappe_manager/site_manager/site.py
+++ b/frappe_manager/site_manager/site.py
@@ -1071,16 +1071,30 @@ class Bench:
         timeout: int = 30,
         interval: int = 1,
         force: bool = False,
+        graceful: bool = False,
     ):
-        return self.supervisor.restart_supervisor_service(service, docker_client_obj, timeout, interval, force)
+        return self.supervisor.restart_supervisor_service(
+            service, docker_client_obj, timeout, interval, force, graceful=graceful
+        )
 
-    def restart_web_containers_services(self, use_container_restart: bool = False, force: bool = False):
+    def restart_web_containers_services(
+        self,
+        use_container_restart: bool = False,
+        force: bool = False,
+        graceful: bool = False,
+    ):
         """
         Restarts frappe server and socketio containers.
 
         Args:
             use_container_restart: If True, restart entire containers. If False, restart supervisor processes.
             force: If True, use aggressive restart (timeout=0 for container, stop+start for supervisor).
+            graceful: If True (supervisor mode only), deliver SIGHUP to the frappe (gunicorn)
+                container via supervisorctl so the gunicorn master keeps its listening socket
+                open while workers reload. Avoids the brief upstream connection-refused window
+                of a stop/start cycle. The socketio container is restarted normally because
+                node has no graceful-reload signal. Ignored when ``use_container_restart`` is
+                True.
         """
         web_services = [
             SiteServicesEnum.frappe.value,
@@ -1092,9 +1106,20 @@ class Bench:
         else:
             for service in web_services:
                 self.output.change_head(f"Restarting web services - {service}")
-                is_restarted = self.restart_supervisor_service(service, force=force)
+                # Graceful SIGHUP is only meaningful for the frappe (gunicorn) container.
+                # Node-socketio terminates on SIGHUP, so honour graceful only for frappe and
+                # fall back to a normal restart for socketio when graceful is requested.
+                service_graceful = graceful and service == SiteServicesEnum.frappe.value
+                is_restarted = self.restart_supervisor_service(
+                    service, force=force, graceful=service_graceful
+                )
                 if is_restarted:
-                    action = "Stopped and started" if force else "Restarted"
+                    if service_graceful:
+                        action = "Reloaded (SIGHUP)"
+                    elif force:
+                        action = "Stopped and started"
+                    else:
+                        action = "Restarted"
                     self.output.print(f"{action} supervisor processes - {service}")
 
     def restart_redis_services_containers(self):

--- a/tests/unit/site_manager/test_bench_supervisor_restart.py
+++ b/tests/unit/site_manager/test_bench_supervisor_restart.py
@@ -1,0 +1,185 @@
+"""Tests for BenchSupervisor.restart_supervisor_service graceful-reload behaviour.
+
+Covers the three branches of the restart path:
+
+* ``force=True`` - hard restart (stop + start).
+* ``graceful=True`` - SIGHUP via supervisorctl (no listening-socket drop).
+* default - supervisorctl restart all.
+
+Also covers the mutual exclusion of ``force`` and ``graceful`` and the wiring
+from ``Bench.restart_web_containers_services`` (graceful is only honoured for
+the frappe/gunicorn container, never for socketio).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from frappe_manager.docker import DockerException
+from frappe_manager.docker.subprocess_output import SubprocessOutput
+from frappe_manager.site_manager.exceptions import BenchOperationException
+from frappe_manager.site_manager.modules.bench_supervisor import BenchSupervisor
+from frappe_manager.site_manager.site import Bench, SiteServicesEnum
+
+
+def _make_supervisor(docker_client: MagicMock) -> BenchSupervisor:
+    """Build a BenchSupervisor with the heavy collaborators stubbed out."""
+    supervisor = BenchSupervisor.__new__(BenchSupervisor)
+    supervisor.bench_name = "test.localhost"
+    supervisor.docker_client = docker_client
+    supervisor.config = MagicMock()
+    supervisor.output = MagicMock()
+    supervisor.logger = MagicMock()
+    return supervisor
+
+
+def _stub_running_service(docker_client: MagicMock, service: str = "frappe") -> None:
+    """Wire ``compose.get_all_services_status`` to report ``service`` as running."""
+    docker_client.compose.get_all_services_status.return_value = [
+        {"Service": service, "State": "running"},
+    ]
+
+
+class TestRestartSupervisorServiceGraceful:
+    """The ``graceful`` branch must send ``supervisorctl signal HUP all`` exactly once."""
+
+    def test_graceful_sends_sighup_via_supervisorctl(self):
+        docker_client = MagicMock()
+        _stub_running_service(docker_client)
+        supervisor = _make_supervisor(docker_client)
+
+        result = supervisor.restart_supervisor_service(
+            service="frappe", graceful=True, timeout=1, interval=0,
+        )
+
+        assert result is True
+
+        exec_calls = docker_client.compose.exec.call_args_list
+        # First call is the SIGHUP; later calls are the socket-existence probe.
+        first_kwargs = exec_calls[0].kwargs
+        assert first_kwargs["service"] == "frappe"
+        assert first_kwargs["user"] == "frappe"
+        assert "signal HUP all" in first_kwargs["command"]
+        assert "supervisorctl" in first_kwargs["command"]
+
+    def test_graceful_does_not_stop_then_start(self):
+        """Graceful must never issue a stop or start - only signal HUP."""
+        docker_client = MagicMock()
+        _stub_running_service(docker_client)
+        supervisor = _make_supervisor(docker_client)
+
+        supervisor.restart_supervisor_service(
+            service="frappe", graceful=True, timeout=1, interval=0,
+        )
+
+        issued_commands = [
+            call.kwargs.get("command", "") for call in docker_client.compose.exec.call_args_list
+        ]
+        assert not any("stop all" in cmd for cmd in issued_commands)
+        assert not any("start all" in cmd for cmd in issued_commands)
+        assert not any("restart all" in cmd for cmd in issued_commands)
+
+    def test_graceful_and_force_are_mutually_exclusive(self):
+        docker_client = MagicMock()
+        _stub_running_service(docker_client)
+        supervisor = _make_supervisor(docker_client)
+
+        with pytest.raises(BenchOperationException):
+            supervisor.restart_supervisor_service(
+                service="frappe", graceful=True, force=True, timeout=1, interval=0,
+            )
+
+        docker_client.compose.exec.assert_not_called()
+
+    def test_graceful_propagates_docker_failure_as_bench_exception(self):
+        docker_client = MagicMock()
+        _stub_running_service(docker_client)
+        supervisor = _make_supervisor(docker_client)
+
+        docker_client.compose.exec.side_effect = DockerException(
+            ["supervisorctl"],
+            SubprocessOutput(stdout=[], stderr=["boom"], combined=["boom"], exit_code=1),
+        )
+
+        with pytest.raises(BenchOperationException) as exc_info:
+            supervisor.restart_supervisor_service(
+                service="frappe", graceful=True, timeout=1, interval=0,
+            )
+
+        assert "signal HUP" in str(exc_info.value)
+
+
+class TestRestartSupervisorServiceForceVsDefault:
+    """Regression checks for the pre-existing force and default branches."""
+
+    def test_force_uses_stop_then_start(self):
+        docker_client = MagicMock()
+        _stub_running_service(docker_client)
+        supervisor = _make_supervisor(docker_client)
+
+        supervisor.restart_supervisor_service(
+            service="frappe", force=True, timeout=1, interval=0,
+        )
+
+        issued_commands = [
+            call.kwargs.get("command", "") for call in docker_client.compose.exec.call_args_list
+        ]
+        assert any("stop all" in cmd for cmd in issued_commands)
+        assert any("start all" in cmd for cmd in issued_commands)
+        assert not any("signal HUP" in cmd for cmd in issued_commands)
+
+    def test_default_uses_restart_all(self):
+        docker_client = MagicMock()
+        _stub_running_service(docker_client)
+        supervisor = _make_supervisor(docker_client)
+
+        supervisor.restart_supervisor_service(
+            service="frappe", timeout=1, interval=0,
+        )
+
+        issued_commands = [
+            call.kwargs.get("command", "") for call in docker_client.compose.exec.call_args_list
+        ]
+        assert any("restart all" in cmd for cmd in issued_commands)
+        assert not any("signal HUP" in cmd for cmd in issued_commands)
+
+
+class TestRestartWebContainersServicesGracefulWiring:
+    """``Bench.restart_web_containers_services`` must scope ``graceful`` to frappe only."""
+
+    def _make_bench(self) -> Bench:
+        bench = Bench.__new__(Bench)
+        bench.name = "test.localhost"
+        bench.output = MagicMock()
+        bench.docker_ops = MagicMock()
+        bench.restart_supervisor_service = MagicMock(return_value=True)
+        return bench
+
+    def test_graceful_only_applied_to_frappe_container(self):
+        bench = self._make_bench()
+
+        bench.restart_web_containers_services(graceful=True)
+
+        called_services = {
+            call.args[0]: call.kwargs.get("graceful")
+            for call in bench.restart_supervisor_service.call_args_list
+        }
+
+        assert called_services[SiteServicesEnum.frappe.value] is True
+        assert called_services[SiteServicesEnum.socketio.value] is False
+
+    def test_graceful_false_passes_false_to_both(self):
+        bench = self._make_bench()
+
+        bench.restart_web_containers_services(graceful=False)
+
+        for call in bench.restart_supervisor_service.call_args_list:
+            assert call.kwargs.get("graceful") is False
+
+    def test_use_container_restart_bypasses_supervisor_path(self):
+        bench = self._make_bench()
+
+        bench.restart_web_containers_services(use_container_restart=True, graceful=True)
+
+        bench.restart_supervisor_service.assert_not_called()
+        bench.docker_ops.restart_services.assert_called_once()

--- a/tests/unit/site_manager/test_bench_supervisor_restart.py
+++ b/tests/unit/site_manager/test_bench_supervisor_restart.py
@@ -62,6 +62,13 @@ class TestRestartSupervisorServiceGraceful:
         assert "signal HUP all" in first_kwargs["command"]
         assert "supervisorctl" in first_kwargs["command"]
 
+        # Regression guard: SIGHUP must be issued exactly once. Any subsequent exec
+        # calls are the socket-existence probe (``test -e ...``), never another HUP.
+        sighup_calls = [
+            call for call in exec_calls if "signal HUP all" in call.kwargs.get("command", "")
+        ]
+        assert len(sighup_calls) == 1
+
     def test_graceful_does_not_stop_then_start(self):
         """Graceful must never issue a stop or start - only signal HUP."""
         docker_client = MagicMock()


### PR DESCRIPTION
## Summary

`fm restart` (and `fmx restart` inside the container) currently issue
`supervisorctl stop && start` for the web service. That stop briefly
closes the gunicorn listening socket; any client that connects in the
window between `stop` and `start` sees a TCP RST or
`connect: connection refused`, which reverse proxies surface as a 502.
For production deployments this is the dominant cause of a small but
consistent 502 burst on every restart — clients reading at the moment
of the stop also see in-flight requests RST'd.

This adds an opt-in `--graceful` flag that recycles workers via
`supervisorctl signal HUP all` instead. The gunicorn master keeps its
listening socket open across the reload, so upstream proxies observe no
connection-refused window and no in-flight RSTs from the listener.

## Behavior

* `fm restart <bench> --graceful` — signals the frappe (gunicorn)
  container with SIGHUP via supervisorctl. The socketio container is
  restarted normally (node has no graceful-reload signal). Worker
  containers are not affected by this flag.
* `fm restart <bench>` (default) — unchanged, still runs
  `supervisorctl restart all`.
* `fm restart <bench> --force` — unchanged, still does the explicit
  `stop && start` cycle for callers that need a hard restart.
* `fmx restart <service> --graceful` — same semantics inside the
  container, dispatching SIGHUP to each process via the supervisor
  XML-RPC API. Composes with the existing `--maintenance-mode` and
  `--drain-workers` orchestration; mutually exclusive with `--migrate`.

`--graceful` is mutually exclusive with `--force` and ignored when
combined with `--container` (a full container restart can't be made
graceful at this layer).

## Mechanism

The web service runs gunicorn with `--preload`. On SIGHUP, the
gunicorn master:

1. Re-reads its configuration.
2. Forks fresh workers against the existing listening socket.
3. Sends each old worker a graceful-shutdown signal once a replacement
   is ready.

At no point does the master close the listening socket, so a
connecting client never observes connect-refused / RST during the
swap. The existing `--preload` setup in `_write_gunicorn_wrapper` is
already compatible with this — no template changes required.

## Backward compatibility

Default behavior is unchanged. The flag is opt-in and the existing
hard-restart path remains the default and is still reachable via
`--force`. No existing callers need to be updated. The pre-existing
`force` and default branches of `BenchSupervisor.restart_supervisor_service`
are untouched; the new `graceful` branch is added alongside them.

## Test plan

- [x] Unit tests added at `tests/unit/site_manager/test_bench_supervisor_restart.py`:
  - graceful sends `supervisorctl signal HUP all` and nothing else
  - graceful never issues stop / start / restart
  - graceful + force raises a `BenchOperationException` before any
    docker command is executed
  - docker failures during the SIGHUP exec surface as
    `BenchOperationException`
  - regression: force still does stop + start; default still does
    `restart all`
  - `Bench.restart_web_containers_services` only applies graceful to
    the frappe container, never to socketio
  - `use_container_restart=True` bypasses the supervisor path entirely
- [ ] Manual: `fm restart <bench> --graceful` against a running bench
      while a load generator hits `/api/method/ping` — confirm zero
      `connection refused` in the access log across the reload window
      (covered manually before opening this PR; reproduction script is
      out of scope here).

## Caveats / follow-up

- With `gunicorn --preload`, SIGHUP recycles workers but does **not**
  re-import application code in the master. This flag is suitable for
  restart-without-RST (release leaked memory, apply runtime config
  changes that workers re-read on fork) but is **not** a substitute for
  a full restart when picking up new application code — for that, a
  follow-up could wire a `--graceful=usr2` path that re-execs the
  gunicorn master. The docs and help text call this out so callers pick
  the right flag.
- The socketio container intentionally falls back to a normal restart
  under `--graceful` because node terminates on SIGHUP. A follow-up
  could investigate a custom signal handler in the socketio entrypoint
  to make socketio reloads non-disruptive too.
- Container-level restart (`--container`) cannot be made graceful at
  this layer — the right place for that is upstream connection-draining
  at the proxy, which is out of scope here.