### PR TITLE
Fix Nginx duplicate directive error and add container stop option

### DIFF
--- a/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
@@ -459,6 +459,8 @@ class MigrationV0190(MigrationBase):
 
     def _write_upload_limit_nginx_conf(self, bench: MigrationBench, upload_limit: str):
         """Create custom nginx config file for bench-level upload limit."""
+        import re
+
         custom_conf_dir = bench.path / "configs" / "nginx" / "conf" / "custom"
         custom_conf_dir.mkdir(parents=True, exist_ok=True)
 
@@ -477,6 +479,19 @@ class MigrationV0190(MigrationBase):
             self.backup_manager.track_new_file(upload_limit_conf)
 
         self.output.print("Created custom nginx upload-limit.conf")
+
+        # Strip any old client_max_body_size from the generated default.conf
+        # to avoid duplicate-directive errors. Older FM versions baked the
+        # value directly into the nginx template; the migration now uses
+        # upload-limit.conf instead, so the old line must be removed.
+        default_conf = bench.path / "configs" / "nginx" / "conf" / "conf.d" / "default.conf"
+        if default_conf.exists():
+            old = default_conf.read_text()
+            cleaned = re.sub(r"\s*client_max_body_size\s+[^;]+;\n?", "", old)
+            if old != cleaned:
+                self.backup_manager.backup(default_conf, bench_name=bench.name)
+                default_conf.write_text(cleaned)
+                self.output.print("Removed duplicate client_max_body_size from default.conf")
 
     def _migrate_workers_compose_yml(self, bench: MigrationBench, compose_path: Path):
         """Update worker compose: v0.18.0 → current version images."""

--- a/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_0.py
@@ -36,6 +36,7 @@ class MigrationV0190(MigrationBase):
 
         Backs up:
         - supervisor.conf and *.fm.supervisor.conf (regenerated during rebuild)
+        - nginx default.conf (may be modified during migration)
 
         Note: env/ backup is handled inside _rebuild_runtime_environment right
         before the Python venv is recreated (so the guard is the same code path).
@@ -55,6 +56,12 @@ class MigrationV0190(MigrationBase):
             for conf_file in supervisor_config_dir.glob("*.fm.supervisor.conf"):
                 self.backup_manager.backup(conf_file, bench_name=bench.name)
                 self.output.print(f"Backed up {conf_file.name}")
+
+        # Backup nginx default.conf — gets modified during migration
+        nginx_default_conf = bench.path / "configs" / "nginx" / "conf" / "conf.d" / "default.conf"
+        if nginx_default_conf.exists():
+            self.backup_manager.backup(nginx_default_conf, bench_name=bench.name)
+            self.output.print("Backed up nginx default.conf")
 
     def _backup_env_for_rollback(self, bench: MigrationBench):
         """Move existing env/ to env.backup.migration for rollback support.

--- a/scripts/migrate-test.sh
+++ b/scripts/migrate-test.sh
@@ -27,6 +27,7 @@
 #   FM_PREVIOUS_REPO   Previous version spec (e.g., git+https://...@fix/install-deps)
 #   FM_REPO            Target version spec (e.g., git+https://...@fix-migrations)
 #   FM_MIGRATE_FLAGS   Migration flags (e.g., --all-benches --auto-proceed)
+#   FM_STOP_CONTAINERS Stop FM containers before migration (default: true)
 #
 
 set -euo pipefail
@@ -42,6 +43,7 @@ set -euo pipefail
 : "${FM_PREVIOUS_REPO:?FM_PREVIOUS_REPO is not set. Create .env or export it.}"
 : "${FM_REPO:?FM_REPO is not set. Create .env or export it.}"
 : "${FM_MIGRATE_FLAGS:?FM_MIGRATE_FLAGS is not set. Create .env or export it.}"
+: "${FM_STOP_CONTAINERS:=true}"   # Set to false to skip stopping containers before migration
 
 SSH_OPTS="-o ConnectTimeout=5 -o BatchMode=yes"
 SSH="ssh $SSH_OPTS $FM_SERVER"
@@ -201,11 +203,15 @@ cmd_init() {
     }
     ok "Bench created: $FM_BENCH"
 
-    # ── Step 6: Stop all FM containers ────────────────────────────────────
+    # ── Step 6: Stop all FM containers (optional) ─────────────────────────
     echo ""
-    info "Stopping all FM containers …"
-    ssh_cmd "docker ps --filter name=fm_ -q | xargs -r docker stop" || true
-    ok "FM containers stopped"
+    if [[ "$FM_STOP_CONTAINERS" == "true" ]]; then
+        info "Stopping all FM containers …"
+        ssh_cmd "docker ps --filter name=fm_ -q | xargs -r docker stop" || true
+        ok "FM containers stopped"
+    else
+        info "Skipping container stop (FM_STOP_CONTAINERS=false)"
+    fi
 
     # ── Step 7: Move ~/frappe → fm.<version>/frappe (migration source) ────
     echo ""
@@ -311,11 +317,15 @@ cmd_test() {
     version=$(install_fm "$FM_REPO" "$FM_PYTHON")
     ok "New version: $version"
 
-    # ── Step 2: Stop all FM containers ──────────────────────────────────
-    echo ""
-    info "Stopping all FM containers …"
-    ssh_cmd "docker ps --filter name=fm_ -q | xargs -r docker stop" || true
-    ok "FM containers stopped"
+    # ── Step 2: Stop all FM containers (optional) ────────────────────────
+    if [[ "$FM_STOP_CONTAINERS" == "true" ]]; then
+        echo ""
+        info "Stopping all FM containers …"
+        ssh_cmd "docker ps --filter name=fm_ -q | xargs -r docker stop" || true
+        ok "FM containers stopped"
+    else
+        info "Skipping container stop (FM_STOP_CONTAINERS=false)"
+    fi
 
     # ── Step 3: Finalize install (temp → fm.<version>) ──────────────────
     echo ""


### PR DESCRIPTION
This pull request improves the migration process by enhancing backup reliability and making the migration test script more flexible. The main changes include backing up and cleaning up the `nginx default.conf` file during migration, and introducing an option to skip stopping containers in the migration test script.

**Migration reliability improvements:**

* The migration now backs up the `nginx default.conf` file, which may be modified during migration, to prevent loss of manual or previous configuration changes. [[1]](diffhunk://#diff-add7e41113d267b7be805783580e5aafbdb4c93e5d5e6f048751ee9595813ccfR39) [[2]](diffhunk://#diff-add7e41113d267b7be805783580e5aafbdb4c93e5d5e6f048751ee9595813ccfR60-R65)
* When setting a custom upload limit, the migration script removes any old `client_max_body_size` directives from `default.conf` to avoid duplicate configuration errors, backing up the file before modification.
* Added an explicit import of the `re` module for regex operations in the migration script.

**Migration test script flexibility:**

* Added the `FM_STOP_CONTAINERS` environment variable to allow skipping the step that stops all FM containers before migration, making the test process more customizable. [[1]](diffhunk://#diff-931d7d74ece90c0031916e9174879de50bfe31b4af3104abb2f14107dca5de33R30) [[2]](diffhunk://#diff-931d7d74ece90c0031916e9174879de50bfe31b4af3104abb2f14107dca5de33R46)
* Updated the script logic to conditionally stop containers based on the value of `FM_STOP_CONTAINERS` in both the `init` and `test` commands. [[1]](diffhunk://#diff-931d7d74ece90c0031916e9174879de50bfe31b4af3104abb2f14107dca5de33L204-R214) [[2]](diffhunk://#diff-931d7d74ece90c0031916e9174879de50bfe31b4af3104abb2f14107dca5de33L314-R328)