### PR TITLE
feat(bench): make gunicorn keep-alive and worker-tmp-dir configurable

### DIFF
--- a/docs/reference/workers.md
+++ b/docs/reference/workers.md
@@ -211,6 +211,29 @@ fm restart mybench
     
     The default formula balances CPU utilization and memory.
 
+### Optional Gunicorn Flags
+
+Two additional Gunicorn flags can be enabled via `common_site_config.json`. Both
+are unset by default, so the generated command is unchanged unless you configure
+them.
+
+| Key | Gunicorn flag | Default |
+| --- | --- | --- |
+| `gunicorn_keep_alive` | `--keep-alive` | unset (flag omitted) |
+| `gunicorn_worker_tmp_dir` | `--worker-tmp-dir` | unset (flag omitted) |
+
+```bash
+# Keep idle connections open longer and put worker heartbeat files on tmpfs
+fm shell mybench -c "bench set-config -g gunicorn_keep_alive 5"
+fm shell mybench -c "bench set-config -g gunicorn_worker_tmp_dir /dev/shm"
+fm restart mybench
+```
+
+!!! note "Wrapper is regenerated"
+    FM regenerates the web-server wrapper on setup, restart, and migrate. Setting
+    these keys in `common_site_config.json` ensures the values survive those
+    operations instead of being reset to defaults.
+
 ---
 
 ## RQ Worker Concurrency

--- a/frappe_manager/site_manager/modules/bench_supervisor.py
+++ b/frappe_manager/site_manager/modules/bench_supervisor.py
@@ -7,6 +7,7 @@ Extracted from the monolithic Bench class for better separation of concerns.
 
 import time
 import json
+import shlex
 import multiprocessing
 from jinja2 import Template
 from frappe_manager.utils.helpers import get_template_path
@@ -214,8 +215,8 @@ class BenchSupervisor:
         # --threads from the gunicorn master cmdline, so gthread is the intended worker type.
         # Default 2 threads per worker; overridable via common_site_config.json.
         gunicorn_threads = config.get("gunicorn_threads", self._get_gunicorn_threads())
-        gunicorn_keep_alive = config.get("gunicorn_keep_alive")  # None -> omit flag (current behavior)
-        gunicorn_worker_tmp_dir = config.get("gunicorn_worker_tmp_dir")  # None -> omit flag (current behavior)
+        gunicorn_keep_alive = config.get("gunicorn_keep_alive")  # omit when unset; 0 is still emitted (is-not-None guard)
+        gunicorn_worker_tmp_dir = config.get("gunicorn_worker_tmp_dir")  # omit when unset or empty (truthiness guard)
 
         context = {
             "bench_dir": CONTAINER_BENCH_DIR,
@@ -393,9 +394,9 @@ class BenchSupervisor:
             f" --graceful-timeout 30"
         )
         if context.get("gunicorn_keep_alive") is not None:
-            gunicorn_args += f" --keep-alive {context['gunicorn_keep_alive']}"
+            gunicorn_args += f" --keep-alive {shlex.quote(str(context['gunicorn_keep_alive']))}"
         if context.get("gunicorn_worker_tmp_dir"):
-            gunicorn_args += f" --worker-tmp-dir {context['gunicorn_worker_tmp_dir']}"
+            gunicorn_args += f" --worker-tmp-dir {shlex.quote(str(context['gunicorn_worker_tmp_dir']))}"
         gunicorn_args += " frappe.app:application --preload"
 
         template_path = get_template_path("fm-web-server.sh.tmpl")

--- a/frappe_manager/site_manager/modules/bench_supervisor.py
+++ b/frappe_manager/site_manager/modules/bench_supervisor.py
@@ -214,6 +214,8 @@ class BenchSupervisor:
         # --threads from the gunicorn master cmdline, so gthread is the intended worker type.
         # Default 2 threads per worker; overridable via common_site_config.json.
         gunicorn_threads = config.get("gunicorn_threads", self._get_gunicorn_threads())
+        gunicorn_keep_alive = config.get("gunicorn_keep_alive")  # None -> omit flag (current behavior)
+        gunicorn_worker_tmp_dir = config.get("gunicorn_worker_tmp_dir")  # None -> omit flag (current behavior)
 
         context = {
             "bench_dir": CONTAINER_BENCH_DIR,
@@ -227,6 +229,8 @@ class BenchSupervisor:
             "gunicorn_max_requests": max_requests,
             "gunicorn_max_requests_jitter": self._compute_max_requests_jitter(max_requests),
             "gunicorn_threads": gunicorn_threads,
+            "gunicorn_keep_alive": gunicorn_keep_alive,
+            "gunicorn_worker_tmp_dir": gunicorn_worker_tmp_dir,
             "bench_name": "frappe-bench",
             "background_workers": config.get("background_workers") or 1,
             "bench_cmd": "/opt/user/.bin/bench",
@@ -387,8 +391,12 @@ class BenchSupervisor:
             f" --max-requests-jitter {context['gunicorn_max_requests_jitter']}"
             f" -t {context['http_timeout']}"
             f" --graceful-timeout 30"
-            f" frappe.app:application --preload"
         )
+        if context.get("gunicorn_keep_alive") is not None:
+            gunicorn_args += f" --keep-alive {context['gunicorn_keep_alive']}"
+        if context.get("gunicorn_worker_tmp_dir"):
+            gunicorn_args += f" --worker-tmp-dir {context['gunicorn_worker_tmp_dir']}"
+        gunicorn_args += " frappe.app:application --preload"
 
         template_path = get_template_path("fm-web-server.sh.tmpl")
         script = Template(template_path.read_text()).render(


### PR DESCRIPTION
## Problem

`frappe_manager/site_manager/modules/bench_supervisor.py` builds the gunicorn command line for the generated web-server wrapper in `_write_gunicorn_wrapper`. Two useful gunicorn runtime flags are not supported there:

- `--keep-alive` — how long gunicorn keeps an idle client connection open between requests.
- `--worker-tmp-dir` — where gunicorn places its per-worker heartbeat files (commonly pointed at a `tmpfs` such as `/dev/shm`).

Because the wrapper is regenerated on `setup` / `restart` / `migrate`, an operator who edits the generated script by hand to add either flag loses that customization on the very next FM operation. There is currently no supported way to set these values persistently.

## Solution

Expose both flags via `common_site_config.json`, consistent with the existing `gunicorn_workers` / `gunicorn_max_requests` / `gunicorn_threads` keys:

| Key | Gunicorn flag | Default |
| --- | --- | --- |
| `gunicorn_keep_alive` | `--keep-alive` | unset (flag omitted) |
| `gunicorn_worker_tmp_dir` | `--worker-tmp-dir` | unset (flag omitted) |

`generate_supervisor_config` reads the two keys and adds them to the render context; `_write_gunicorn_wrapper` conditionally appends the flags only when they are configured.

## Backward compatibility

Defaults preserve current behavior exactly. When neither key is set, the generated command is **byte-identical** to today's output — no `--keep-alive`, no `--worker-tmp-dir`.

**Default (both keys unset):**

```
-b 0.0.0.0:80 -w 5 --worker-class=gthread --threads 2 --max-requests 1000 --max-requests-jitter 100 -t 120 --graceful-timeout 30 frappe.app:application --preload
```

**With `gunicorn_keep_alive=5` and `gunicorn_worker_tmp_dir=/dev/shm`:**

```
-b 0.0.0.0:80 -w 5 --worker-class=gthread --threads 2 --max-requests 1000 --max-requests-jitter 100 -t 120 --graceful-timeout 30 --keep-alive 5 --worker-tmp-dir /dev/shm frappe.app:application --preload
```

Emission rules:

- `gunicorn_keep_alive` uses an `is not None` check, so an explicit `0` still emits `--keep-alive 0` (a valid gunicorn value); leaving the key unset omits the flag.
- `gunicorn_worker_tmp_dir` is emitted only when set to a non-empty path.

## Usage

```bash
fm shell mybench -c "bench set-config -g gunicorn_keep_alive 5"
fm shell mybench -c "bench set-config -g gunicorn_worker_tmp_dir /dev/shm"
fm restart mybench
```

## Scope notes

- `--graceful-timeout` is intentionally **not** touched here — it is left hardcoded at `30`, exactly as on `develop`, because making it configurable is already handled by #418. This PR is scoped to the two flags that no open PR covers.
- Gunicorn's `--keep-alive` (idle client-connection lifetime on the gunicorn side) complements the nginx-to-gunicorn upstream keepalive added in #417; the two operate at different layers and are independent.

Docs: adds an "Optional Gunicorn Flags" subsection to `docs/reference/workers.md` documenting the two new keys.
