### PR TITLE
fix: add workflow_dispatch to publish-pypi for manual retry

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,6 +3,11 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.19.0)'
+        required: true
 
 jobs:
   publish:
@@ -12,12 +17,26 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Set tag
+        id: tag
+        env:
+          TRIGGER: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$TRIGGER" = "workflow_dispatch" ]; then
+            echo "value=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download dist from release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.value }}
         run: |
           mkdir dist
-          gh release download "${{ github.event.release.tag_name }}" \
+          gh release download "$TAG" \
             --repo "${{ github.repository }}" \
             --dir dist/ \
             --pattern "*.whl" \


### PR DESCRIPTION
This pull request enhances the PyPI publishing workflow by allowing manual triggering with a specific release tag and making the tag selection more flexible. The most important changes are:

**Workflow Trigger Improvements:**

* Added support for manual workflow dispatch (`workflow_dispatch`) with a required `tag` input, allowing the workflow to be started manually and specifying which release tag to use.

**Tag Handling Logic:**

* Introduced a new step to determine the correct tag to use based on whether the workflow was triggered by a release event or manually, ensuring the correct artifacts are downloaded and published.
* Updated the artifact download step to use the dynamically selected tag, improving reliability when publishing from different triggers.