### PR TITLE
Add Chromium libraries for PDF generation and improve CI workflows

### DIFF
--- a/.github/workflows/bake-images.yml
+++ b/.github/workflows/bake-images.yml
@@ -21,17 +21,15 @@ jobs:
   build-and-push:
     name: Build and push image
     strategy:
+      # One arch failing must not cancel the other.
+      fail-fast: false
       matrix:
-        os: [self-hosted-arm64,ubuntu-latest]
-        platform: [linux/amd64, linux/arm64]
         service_name: [frappe, nginx]
-        exclude:
-          - os: ubuntu-latest
-            platform: linux/arm64
-          - os: self-hosted-arm64
-            platform: linux/amd64
+        target:
+          - { os: ubuntu-latest, platform: linux/amd64, arch: amd64 }
+          - { os: ubuntu-24.04-arm, platform: linux/arm64, arch: arm64 }
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -70,7 +68,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.target.platform }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -86,37 +84,68 @@ jobs:
           version=$(grep '^__version__' frappe_manager/__about__.py | sed 's/__version__ = "\(.*\)"/\1/')
           tag="v${version}"
           echo "Image tag $tag"
-          echo "image_name=ghcr.io/${owner}/frappe-manager-${{ matrix.service_name }}:$(basename ${{ matrix.platform }})-${tag}" >> $GITHUB_ENV
+          echo "image_name=ghcr.io/${owner}/frappe-manager-${{ matrix.service_name }}:${{ matrix.target.arch }}-${tag}" >> $GITHUB_ENV
 
       - name: Set owner
         run: |
           echo "owned=$( echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]' )" >> $GITHUB_ENV
+
+      # cache-from needs a multi-line value, which a ${{ }} expression cannot
+      # produce, so the refs are assembled here.
+      - name: Compute build cache refs
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          ARCH: ${{ matrix.target.arch }}
+          SERVICE: ${{ matrix.service_name }}
+        run: |
+          # Tag and nightly builds both build the latest release tag, so they
+          # share one scope instead of leaving a dead cache ref per release.
+          if [ "$EVENT_NAME" = "schedule" ] || [ "$REF_TYPE" = "tag" ]; then
+            scope="release"
+          else
+            # OCI tags cannot contain '/', so refs like dockerimage/1 must be
+            # flattened. printf avoids tr eating the trailing newline.
+            scope=$(printf '%s' "$REF_NAME" | tr -c 'a-zA-Z0-9_.-' '-' | cut -c1-100)
+          fi
+          echo "Cache scope: $scope"
+
+          repo="ghcr.io/${owned}/frappe-manager-${SERVICE}"
+
+          # Scoped, then develop's, then the legacy shared ref, so adopting
+          # scoped caches never forces a cold build. Drop the legacy entry once
+          # every active branch has populated its own.
+          {
+            echo "cache_from<<CACHE_FROM_EOF"
+            echo "type=registry,ref=${repo}:buildcache-${ARCH}-${scope}"
+            echo "type=registry,ref=${repo}:buildcache-${ARCH}-develop"
+            echo "type=registry,ref=${repo}:buildcache-${ARCH}"
+            echo "CACHE_FROM_EOF"
+          } >> "$GITHUB_ENV"
+
+          # Write scope-only, so no branch can clobber another's cache.
+          echo "cache_to=type=registry,ref=${repo}:buildcache-${ARCH}-${scope},mode=max" >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: Docker/${{ matrix.service_name }}/.
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.target.platform }}
           tags: ${{ env.image_name }}
           provenance: false
-          cache-from: ${{ env.USE_CACHE == 'true' && format('type=registry,ref=ghcr.io/{0}/frappe-manager-{1}:buildcache-{2}', env.owned, matrix.service_name, matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}
-          cache-to: ${{ format('type=registry,ref=ghcr.io/{0}/frappe-manager-{1}:buildcache-{2},mode=max', env.owned, matrix.service_name, matrix.platform == 'linux/amd64' && 'amd64' || 'arm64') || '' }}
-
-      - name: Prune buildx cache (self-hosted only)
-        if: startsWith(matrix.os, 'self-hosted')
-        run: |
-          docker buildx prune -af
+          cache-from: ${{ env.USE_CACHE == 'true' && env.cache_from || '' }}
+          cache-to: ${{ env.cache_to }}
 
   combine:
     name: Combine both platform images
     needs: build-and-push
     strategy:
       matrix:
-        os: [ubuntu-latest]
         service_name: [frappe, nginx]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -58,17 +58,18 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Extract release notes from changelog
+      # The tag drives the package version and the published image tag.
+      - name: Verify version matches tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          python3 -c "
-          import re, sys
-          with open('docs/changelog.md') as f:
-              content = f.read()
-          pattern = rf'(## v{re.escape(sys.argv[1])}.*?)(?=\n## v|\Z)'
-          match = re.search(pattern, content, re.DOTALL)
-          print(match.group(1).strip() if match else f'Release {sys.argv[1]}')
-          " "$VERSION" > release-notes.md
+          DECLARED=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frappe_manager/__about__.py)
+          if [ "$DECLARED" != "$VERSION" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match frappe_manager/__about__.py ($DECLARED)"
+            exit 1
+          fi
+
+      - name: Extract release notes from changelog
+        run: python3 scripts/release_notes.py "${GITHUB_REF_NAME#v}" --output release-notes.md
 
       - name: Create draft GitHub Release
         env:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -29,6 +29,16 @@ jobs:
             exit 1
           fi
 
+      # The cumulative changelog is only ever committed to main, so develop's copy
+      # is stale. Prepending onto it would drop every section main has since
+      # accumulated, and then conflict with main at merge time.
+      - name: Base changelog on main
+        run: |
+          git fetch origin main
+          git checkout origin/main -- docs/changelog.md
+          echo "Sections currently in the changelog:"
+          grep -c '^## v' docs/changelog.md
+
       - name: Update changelog
         uses: orhun/git-cliff-action@v4
         with:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -48,6 +48,27 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # hatchling reads the package version from this file, and bake-images.yml
+      # derives the published image tag from it, so a release branch left at
+      # develop's dev version would publish images under the dev tag.
+      - name: Set release version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          sed -i "s/^__version__ = \".*\"/__version__ = \"${VERSION}\"/" frappe_manager/__about__.py
+
+          DECLARED=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frappe_manager/__about__.py)
+          if [ "$DECLARED" != "$VERSION" ]; then
+            echo "::error::failed to set version in frappe_manager/__about__.py (got '$DECLARED')"
+            exit 1
+          fi
+          echo "frappe_manager/__about__.py -> $DECLARED"
+
+      - name: Verify changelog contains the new section
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: python3 scripts/release_notes.py "$VERSION" >/dev/null
+
       - name: Open release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +78,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add docs/changelog.md
+          git add docs/changelog.md frappe_manager/__about__.py
           git commit -m "chore(release): prepare for v${VERSION}"
           git push origin "$BRANCH"
           gh pr create \
@@ -67,7 +88,11 @@ jobs:
             --body "## Release v${VERSION}
 
           Review the generated changelog entries below before merging.
-          Merging this PR will automatically create the \`v${VERSION}\` tag and trigger the publish workflow.
+          Merging this PR creates the \`v${VERSION}\` tag, which triggers the draft
+          release and the image build.
 
-          - [ ] Changelog entries look correct
-          - [ ] Version in \`pyproject.toml\` is \`${VERSION}\`"
+          \`docs/changelog.md\` is based on main's copy and \`frappe_manager/__about__.py\`
+          has been set to \`${VERSION}\` automatically.
+
+          - [ ] Changelog entries look correct and complete
+          - [ ] No entries from previous releases have been duplicated"

--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   tag:
@@ -17,49 +16,34 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # A tag pushed with the default GITHUB_TOKEN does not start new workflow
+          # runs, which would leave draft-release.yml and bake-images.yml unfired.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
+      # Tagging only. draft-release.yml owns building and creating the release off
+      # the resulting tag push.
       - name: Create and push tag
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HAS_PAT: ${{ secrets.RELEASE_PAT != '' }}
         run: |
           VERSION=$(echo "$HEAD_REF" | sed 's|^release/||')
 
           if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Error: branch '$HEAD_REF' does not match release/vX.Y.Z — aborting."
+            echo "Error: branch '$HEAD_REF' does not match release/vX.Y.Z. Aborting."
+            exit 1
+          fi
+
+          DECLARED=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frappe_manager/__about__.py)
+          if [ "v$DECLARED" != "$VERSION" ]; then
+            echo "::error::tag $VERSION does not match frappe_manager/__about__.py ($DECLARED). Images would publish under the wrong tag."
             exit 1
           fi
 
           git tag "$VERSION"
           git push origin "$VERSION"
+          echo "Pushed $VERSION"
 
-      - uses: astral-sh/setup-uv@v8.2.0
-
-      - name: Build
-        run: uv build
-
-      - name: Extract release notes from changelog
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          VERSION=$(echo "$HEAD_REF" | sed 's|^release/||;s|^v||')
-          python3 -c "
-          import re, sys
-          with open('docs/changelog.md') as f:
-              content = f.read()
-          pattern = rf'(## v{re.escape(sys.argv[1])}.*?)(?=\n## v|\Z)'
-          match = re.search(pattern, content, re.DOTALL)
-          print(match.group(1).strip() if match else f'Release {sys.argv[1]}')
-          " "$VERSION" > release-notes.md
-
-      - name: Create draft GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          VERSION=$(echo "$HEAD_REF" | sed 's|^release/||')
-          gh release create "$VERSION" \
-            --title "$VERSION" \
-            --notes-file release-notes.md \
-            --verify-tag \
-            --draft \
-            dist/*
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::RELEASE_PAT is not configured, so this tag was pushed with GITHUB_TOKEN and will NOT trigger draft-release.yml or bake-images.yml. Run both manually via workflow_dispatch against the $VERSION tag."
+          fi

--- a/Docker/frappe/Dockerfile
+++ b/Docker/frappe/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     unzip \
     # Chromium runtime libs for frappe's chrome PDF generator (frappe downloads
     # headless_shell itself). jammy has no chromium-headless-shell package and
-    # chromium-browser is a snap stub, so the libs are listed individually. #452
+    # chromium-browser is a snap stub, so the libs are listed individually
     libnss3 \
     libnspr4 \
     libatk1.0-0 \

--- a/Docker/frappe/Dockerfile
+++ b/Docker/frappe/Dockerfile
@@ -64,6 +64,21 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     fonts-powerline \
     file \
     unzip \
+    # Chromium runtime libs for frappe's chrome PDF generator (frappe downloads
+    # headless_shell itself). jammy has no chromium-headless-shell package and
+    # chromium-browser is a snap stub, so the libs are listed individually. #452
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libxkbcommon0 \
+    libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \

--- a/frappe_manager/commands/migrate.py
+++ b/frappe_manager/commands/migrate.py
@@ -205,22 +205,23 @@ def migrate(
 
     if target_benches:
         for bench_name in target_benches:
-            if bench_name in migrations.migrate_benches:
-                bench_data = migrations.migrate_benches[bench_name]
-                last_migrated = bench_data["last_migration_version"]
+            bench_data = migrations.migrate_benches.get(bench_name)
 
-                # Compare base versions to handle dev releases (0.19.0.dev0 matches 0.19.0)
-                versions_match = (
-                    last_migrated is not None and last_migrated.base_version == current_version.base_version
-                )
+            if bench_data and bench_data["exception"]:
+                benches_failed.append(bench_name)
+                continue
 
-                if versions_match and not bench_data["exception"]:
-                    bench_path = CLI_BENCHES_DIRECTORY / bench_name
-                    if bench_path.exists() and (bench_path / CLI_BENCH_CONFIG_FILE_NAME).exists():
-                        set_bench_migration_version(bench_path, current_version)
-                        benches_migrated.append(bench_name)
-                elif bench_data["exception"]:
-                    benches_failed.append(bench_name)
+            # The run succeeded, so every bench that did not fail is at the current
+            # version — including benches no migration touched, because the release
+            # ships none for them. Keying the stamp off the last applied migration
+            # would leave those benches pinned to their old version forever, and
+            # every later command would keep demanding a migration that does nothing.
+            bench_path = CLI_BENCHES_DIRECTORY / bench_name
+            if bench_path.exists() and (bench_path / CLI_BENCH_CONFIG_FILE_NAME).exists():
+                set_bench_migration_version(bench_path, current_version)
+
+            if bench_data:
+                benches_migrated.append(bench_name)
             else:
                 benches_skipped.append(bench_name)
 

--- a/frappe_manager/migration_manager/migration_base.py
+++ b/frappe_manager/migration_manager/migration_base.py
@@ -204,7 +204,10 @@ class MigrationBase(ABC):
         if bench_config_path.exists():
             self.backup_manager.backup(bench_config_path, bench_name=bench.name)
 
-        self.backup_manager.backup(bench.path / "docker-compose.yml", bench_name=bench.name)
+        # Migrations rewrite the worker compose too, and the rollback in
+        # migrate_benches() can only restore what was backed up here.
+        for compose_path in bench.managed_compose_paths:
+            self.backup_manager.backup(compose_path, bench_name=bench.name)
 
         bench_common_site_config = bench.path / "workspace" / "frappe-bench" / "sites" / "common_site_config.json"
         self.backup_manager.backup(bench_common_site_config, bench_name=bench.name)

--- a/frappe_manager/migration_manager/migration_helpers.py
+++ b/frappe_manager/migration_manager/migration_helpers.py
@@ -29,6 +29,20 @@ class MigrationBench:
         )
 
     @property
+    def managed_compose_paths(self) -> list[Path]:
+        """Compose files fm generates for a bench, filtered to those on disk.
+
+        Not a ``docker-compose*.yml`` glob: that would also claim files fm never
+        created, such as a user's own docker-compose.override.yml.
+        """
+        declared = [
+            self.compose_file_manager.compose_path,
+            self.workers_compose_file_manager.compose_path,
+            self.path / "docker-compose.admin-tools.yml",
+        ]
+        return [path for path in declared if path.is_file()]
+
+    @property
     def compose(self):
         assert self.docker.compose is not None
         return self.docker.compose

--- a/frappe_manager/migration_manager/migrations/migrate_0_19_1.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_1.py
@@ -23,31 +23,12 @@ FM_IMAGE_PATTERN = re.compile(r"(ghcr\.io/rtcamp/frappe-manager-[^:]+):v[0-9]+\.
 class MigrationV0191(MigrationBase):
     version = Version("0.19.1")
 
-    def bench_basic_backup(self, bench: MigrationBench):
-        """Back up every compose file this migration rewrites.
-
-        The parent only backs up docker-compose.yml, but the worker and
-        admin-tools compose files reference the same images and are rewritten
-        here too, so they have to be recoverable for the rollback in
-        MigrationBase.migrate_benches() to be complete.
-        """
-        super().bench_basic_backup(bench)
-
-        if self.migration_executor.skip_backup or bench.name in self.migration_executor.skip_backup_for:
-            return
-
-        for compose_path in self._compose_files(bench):
-            if compose_path.name == "docker-compose.yml":
-                continue  # already handled by the parent
-            self.backup_manager.backup(compose_path, bench_name=bench.name)
-            self.output.print(f"Backed up {compose_path.name}")
-
     def migrate_bench(self, bench: MigrationBench):
         """Re-tag fm images across every compose file, then pull if anything moved."""
         self._images_updated = False
 
         with spinner(self.output, f"Updating image tags for {bench.name}"):  # type: ignore[arg-type]
-            for compose_path in self._compose_files(bench):
+            for compose_path in bench.managed_compose_paths:
                 self._migrate_compose_file(compose_path)
 
             # Skip the pull when nothing changed, so re-running on an
@@ -59,10 +40,6 @@ class MigrationV0191(MigrationBase):
             self.output.print(f"{bench.name} already on {self.version.version_string()} images")
 
         self.output.print(f"Successfully migrated {bench.name} to {self.version.version_string()}")
-
-    def _compose_files(self, bench: MigrationBench) -> list[Path]:
-        """Every compose file in the bench, so a new one cannot be silently missed."""
-        return sorted(p for p in bench.path.glob("docker-compose*.yml") if p.is_file())
 
     def _migrate_compose_file(self, compose_path: Path):
         yaml = YAML(typ="rt")

--- a/frappe_manager/migration_manager/migrations/migrate_0_19_1.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_1.py
@@ -1,0 +1,123 @@
+"""
+Migration for v0.19.1 - move benches onto the v0.19.1 images.
+
+v0.19.1 carries no structural changes. Its only job is to re-tag each bench's
+compose images so they pick up the frappe image that ships Chromium's shared
+libraries, without which Frappe v16's chrome PDF generator cannot start.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from frappe_manager.migration_manager.migration_base import MigrationBase
+from frappe_manager.migration_manager.migration_helpers import MigrationBench
+from frappe_manager.migration_manager.version import Version
+from frappe_manager.output_manager.context_managers import spinner
+
+FM_IMAGE_PATTERN = re.compile(r"(ghcr\.io/rtcamp/frappe-manager-[^:]+):v[0-9]+\.[0-9]+\.[0-9]+(?:\.dev[0-9]+)?")
+
+
+class MigrationV0191(MigrationBase):
+    version = Version("0.19.1")
+
+    def bench_basic_backup(self, bench: MigrationBench):
+        """Back up every compose file this migration rewrites.
+
+        The parent only backs up docker-compose.yml, but the worker and
+        admin-tools compose files reference the same images and are rewritten
+        here too, so they have to be recoverable for the rollback in
+        MigrationBase.migrate_benches() to be complete.
+        """
+        super().bench_basic_backup(bench)
+
+        if self.migration_executor.skip_backup or bench.name in self.migration_executor.skip_backup_for:
+            return
+
+        for compose_path in self._compose_files(bench):
+            if compose_path.name == "docker-compose.yml":
+                continue  # already handled by the parent
+            self.backup_manager.backup(compose_path, bench_name=bench.name)
+            self.output.print(f"Backed up {compose_path.name}")
+
+    def migrate_bench(self, bench: MigrationBench):
+        """Re-tag fm images across every compose file, then pull if anything moved."""
+        self._images_updated = False
+
+        with spinner(self.output, f"Updating image tags for {bench.name}"):  # type: ignore[arg-type]
+            for compose_path in self._compose_files(bench):
+                self._migrate_compose_file(compose_path)
+
+            # Skip the pull when nothing changed, so re-running on an
+            # already-correct bench cannot fail on a transient registry error.
+            if self._images_updated:
+                self._pull_bench_images(bench)
+
+        if not self._images_updated:
+            self.output.print(f"{bench.name} already on {self.version.version_string()} images")
+
+        self.output.print(f"Successfully migrated {bench.name} to {self.version.version_string()}")
+
+    def _compose_files(self, bench: MigrationBench) -> list[Path]:
+        """Every compose file in the bench, so a new one cannot be silently missed."""
+        return sorted(p for p in bench.path.glob("docker-compose*.yml") if p.is_file())
+
+    def _migrate_compose_file(self, compose_path: Path):
+        yaml = YAML(typ="rt")
+        yaml.preserve_quotes = True
+        yaml.default_flow_style = False
+
+        with compose_path.open() as f:
+            compose_data = yaml.load(f)
+
+        if not compose_data or "services" not in compose_data:
+            return
+
+        services = compose_data["services"]
+
+        # Skip files with no fm images, so admin-tools is not reformatted and given
+        # an x-version key it never had.
+        if not any(FM_IMAGE_PATTERN.search(str(svc.get("image", ""))) for svc in services.values()):
+            return
+
+        self._update_service_images(services, compose_path.name)
+
+        # Plain semver, no ``v`` prefix, matching v0.19.0.
+        compose_data["x-version"] = str(self.version)
+
+        with compose_path.open("w") as f:
+            yaml.dump(compose_data, f)
+
+    def _update_service_images(self, services: dict[str, Any], filename: str):
+        effective_tag = self._get_image_tag_for_migration()
+
+        for service_name, service_config in services.items():
+            if "image" not in service_config:
+                continue
+
+            old_image = service_config["image"]
+            new_image = FM_IMAGE_PATTERN.sub(rf"\1:{effective_tag}", old_image)
+
+            if new_image == old_image:
+                continue
+
+            old_tag_match = re.search(r":v([0-9]+\.[0-9]+\.[0-9]+(?:\.dev[0-9]+)?)", old_image)
+            old_tag = old_tag_match.group(1) if old_tag_match else "unknown"
+
+            service_config["image"] = new_image
+            self._images_updated = True
+            self.output.print(f"{filename}: {service_name} image v{old_tag} -> {effective_tag}")
+
+    def _pull_bench_images(self, bench: MigrationBench):
+        from frappe_manager.migration_manager.migration_exections import MigrationExceptionInBench
+
+        self.output.print(f"Pulling updated images ({self._get_image_tag_for_migration()})...", emoji_code="📦")
+
+        result = bench.compose.pull(stream=False)
+
+        if result.exit_code != 0:
+            raise MigrationExceptionInBench(f"Failed to pull images for {bench.name}. Docker pull failed.")
+
+        self.output.print("✓ Images ready", emoji_code="✅")

--- a/frappe_manager/migration_manager/migrations/migrate_0_19_1.py
+++ b/frappe_manager/migration_manager/migrations/migrate_0_19_1.py
@@ -3,7 +3,8 @@ Migration for v0.19.1 - move benches onto the v0.19.1 images.
 
 v0.19.1 carries no structural changes. Its only job is to re-tag each bench's
 compose images so they pick up the frappe image that ships Chromium's shared
-libraries, without which Frappe v16's chrome PDF generator cannot start.
+libraries, without which Frappe v16's chrome PDF generator cannot start, and to
+recreate already-running containers so they run off the new image immediately.
 """
 
 import re
@@ -24,8 +25,11 @@ class MigrationV0191(MigrationBase):
     version = Version("0.19.1")
 
     def migrate_bench(self, bench: MigrationBench):
-        """Re-tag fm images across every compose file, then pull if anything moved."""
+        """Re-tag fm images across every compose file, then pull and recreate if anything moved."""
         self._images_updated = False
+
+        bench_was_running = bench.running
+        workers_were_running = bench.workers_running
 
         with spinner(self.output, f"Updating image tags for {bench.name}"):  # type: ignore[arg-type]
             for compose_path in bench.managed_compose_paths:
@@ -35,6 +39,7 @@ class MigrationV0191(MigrationBase):
             # already-correct bench cannot fail on a transient registry error.
             if self._images_updated:
                 self._pull_bench_images(bench)
+                self._recreate_services(bench, bench_was_running, workers_were_running)
 
         if not self._images_updated:
             self.output.print(f"{bench.name} already on {self.version.version_string()} images")
@@ -98,3 +103,45 @@ class MigrationV0191(MigrationBase):
             raise MigrationExceptionInBench(f"Failed to pull images for {bench.name}. Docker pull failed.")
 
         self.output.print("✓ Images ready", emoji_code="✅")
+
+    def _recreate_services(self, bench: MigrationBench, bench_was_running: bool, workers_were_running: bool):
+        """Recreate containers that were already up, so they run off the re-tagged image.
+
+        Re-tagging compose alone leaves a running bench on the old image until the
+        next stop/start — which is exactly the image missing Chromium's libraries.
+        """
+        if not (bench_was_running or workers_were_running):
+            return
+
+        self.output.print("Recreating containers on the new images...", emoji_code="🔄")
+
+        try:
+            # pull="never": _pull_bench_images already fetched the new tags.
+            if bench_was_running:
+                bench.compose.up(detach=True, pull="never")
+                self._ensure_nginx_running(bench)
+
+            if workers_were_running:
+                bench.workers_docker.compose.up(detach=True, pull="never")
+
+            self.output.print("✓ Containers recreated", emoji_code="✅")
+        except Exception as e:
+            self.output.warning(f"Container recreation failed: {e}")
+            self.output.warning(f"Run 'fm restart {bench.name}' to start using the new images.")
+
+    def _ensure_nginx_running(self, bench: MigrationBench):
+        """Bring nginx back up if the parallel recreate raced it past frappe.
+
+        nginx declares no depends_on and sets ``restart: no``, so a recreate that
+        starts it before frappe rejoins the network kills it for good:
+
+            nginx: [emerg] host not found in upstream "frappe:80"
+
+        The bench then answers nothing until the next ``fm start``. That command
+        guards the same race in start_bench(), so this mirrors it.
+        """
+        if bench.get_services_running_status().get("nginx") == "running":
+            return
+
+        self.output.print("nginx lost the race with frappe, restarting it", emoji_code="🔄")
+        bench.compose.up(services=["nginx"], detach=True, pull="never")

--- a/justfile
+++ b/justfile
@@ -120,6 +120,22 @@ check-actions:
         echo "All actions up to date."
     fi
 
+# ── Changelog ─────────────────────────────────────────────────────────────────
+# docs/changelog.md is generated output, not a file to hand-edit. These recipes
+# preview what the Prepare Release workflow would produce.
+
+# Preview the unreleased section that the next release would add
+changelog:
+    uvx git-cliff --config cliff.toml --unreleased
+
+# Preview the section as it would be titled for a specific version
+changelog-for VERSION:
+    uvx git-cliff --config cliff.toml --unreleased --tag v{{VERSION}}
+
+# Show the release notes that would be published for an already-generated version
+release-notes VERSION:
+    uv run python scripts/release_notes.py {{VERSION}}
+
 # ── Docs generation ──────────────────────────────────────────────────────────
 
 # Generate command reference docs from the live CLI

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Extract one version's section out of docs/changelog.md for GitHub release notes.
+
+Exits non-zero when the section is missing. The inline version this replaced fell
+back to printing ``Release <version>``, so a missing section produced an
+empty-looking release with nothing in the logs to explain it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CHANGELOG = Path("docs/changelog.md")
+
+
+def extract_section(changelog: str, version: str) -> str | None:
+    """Return the ``## v<version>`` section, or None when it is absent.
+
+    The ``(?![0-9.])`` matters: without it, ``0.19.1`` also matches a
+    ``## v0.19.10`` heading and would ship the wrong notes.
+    """
+    pattern = rf"^## v{re.escape(version)}(?![0-9.]).*?(?=^## v|\Z)"
+    match = re.search(pattern, changelog, re.DOTALL | re.MULTILINE)
+    return match.group(0).strip() if match else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="release version without the leading v, e.g. 0.19.1")
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=DEFAULT_CHANGELOG,
+        help=f"path to the changelog (default: {DEFAULT_CHANGELOG})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write the section here instead of stdout",
+    )
+    args = parser.parse_args(argv)
+
+    version = args.version.lstrip("v")
+
+    if not args.changelog.is_file():
+        print(f"::error::changelog not found at {args.changelog}", file=sys.stderr)
+        return 1
+
+    section = extract_section(args.changelog.read_text(encoding="utf-8"), version)
+
+    if section is None:
+        headings = re.findall(r"^## (v\S+)", args.changelog.read_text(encoding="utf-8"), re.MULTILINE)
+        print(
+            f"::error::no '## v{version}' section in {args.changelog}. "
+            f"Found: {', '.join(headings[:10]) or 'none'}. "
+            "Run the Prepare Release workflow so git-cliff generates it before tagging.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.output:
+        args.output.write_text(section + "\n", encoding="utf-8")
+        print(f"wrote {len(section.splitlines())} lines to {args.output}")
+    else:
+        print(section)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/cli/test_migrate_bench_stamping.py
+++ b/tests/unit/cli/test_migrate_bench_stamping.py
@@ -1,0 +1,192 @@
+"""
+Tests for bench migration-version stamping in ``fm migrate``.
+
+After a successful migration run, every targeted bench that did not fail must be
+stamped to the *running* fm version — including benches that no migration
+touched. Keying the stamp off the last applied migration version left benches
+pinned to an older version forever, so every later command kept demanding a
+migration that did nothing.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import typer
+
+from frappe_manager.commands.migrate import migrate
+from frappe_manager.migration_manager.version import Version
+
+RUNNING_FM_VERSION = "0.20.0.dev0"
+
+
+def make_bench(benches_dir: Path, name: str) -> Path:
+    """Create a bench directory that looks migratable (has a bench config)."""
+    bench_path = benches_dir / name
+    bench_path.mkdir(parents=True)
+    (bench_path / "bench_config.toml").write_text("")
+    return bench_path
+
+
+def bench_entry(last_migration_version: str = "0.19.1", exception=None, traceback=None):
+    """Build a ``MigrationExecutor.migrate_benches`` entry for one bench."""
+    return {
+        "object": Mock(),
+        "exception": exception,
+        "last_migration_version": Version(last_migration_version),
+        "traceback": traceback,
+    }
+
+
+def run_migrate(ctx, benches_dir: Path, migrate_benches: dict, **overrides):
+    """
+    Call ``migrate()`` directly with the stamping collaborators patched.
+
+    Returns the patched ``set_bench_migration_version`` mock.
+    """
+    params = {
+        "benchname": None,
+        "all_benches": False,
+        "skip_backup": False,
+        "skip_backup_for": None,
+        "exclude_bench": None,
+        "auto_proceed": True,
+        "rerun": False,
+        "on_failure": None,
+    }
+    params.update(overrides)
+
+    executor = Mock()
+    executor.execute.return_value = True
+    executor.migrate_benches = migrate_benches
+
+    with (
+        patch("frappe_manager.commands.migrate.CLI_BENCHES_DIRECTORY", benches_dir),
+        patch("frappe_manager.commands.migrate.MigrationExecutor", return_value=executor),
+        patch("frappe_manager.commands.migrate.get_current_fm_version", return_value=RUNNING_FM_VERSION),
+        patch("frappe_manager.commands.migrate.set_bench_migration_version") as mock_stamp,
+    ):
+        migrate(ctx, **params)
+
+    return mock_stamp
+
+
+@pytest.fixture
+def benches_dir(tmp_path):
+    """Stand-in for CLI_BENCHES_DIRECTORY."""
+    path = tmp_path / "benches"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def ctx():
+    """Typer context carrying an FM config manager on an older system version."""
+    context = MagicMock(spec=typer.Context)
+    fm_config_manager = Mock()
+    fm_config_manager.get_system_migration_version.return_value = Version("0.19.1")
+    context.obj = {"fm_config_manager": fm_config_manager}
+    return context
+
+
+class TestBenchStampedToRunningVersion:
+    """A successful run stamps the running fm version, whatever migrations ran."""
+
+    def test_older_migration_version_still_stamps_running_version(self, ctx, benches_dir):
+        """
+        Regression: last migration was 0.19.1 while fm runs 0.20.0.dev0.
+
+        The bench must be stamped to 0.20.0.dev0 — not to the migration's own
+        version, and not skipped. Skipping here is what made `fm start` keep
+        demanding a migration.
+        """
+        bench_path = make_bench(benches_dir, "test.local")
+
+        stamp = run_migrate(
+            ctx,
+            benches_dir,
+            {"test.local": bench_entry(last_migration_version="0.19.1")},
+            benchname="test.local",
+        )
+
+        stamp.assert_called_once_with(bench_path, Version(RUNNING_FM_VERSION))
+        stamped_path, stamped_version = stamp.call_args[0]
+        assert stamped_path == bench_path
+        assert str(stamped_version) == RUNNING_FM_VERSION
+
+    def test_no_migration_ran_still_stamps_running_version(self, ctx, benches_dir):
+        """A release shipping no migration for the bench still advances its stamp."""
+        bench_path = make_bench(benches_dir, "test.local")
+
+        stamp = run_migrate(ctx, benches_dir, {}, benchname="test.local")
+
+        stamp.assert_called_once_with(bench_path, Version(RUNNING_FM_VERSION))
+
+    def test_matching_versions_still_stamps(self, ctx, benches_dir):
+        """The ordinary path (migration version == running version) is unchanged."""
+        bench_path = make_bench(benches_dir, "test.local")
+
+        stamp = run_migrate(
+            ctx,
+            benches_dir,
+            {"test.local": bench_entry(last_migration_version=RUNNING_FM_VERSION)},
+            benchname="test.local",
+        )
+
+        stamp.assert_called_once_with(bench_path, Version(RUNNING_FM_VERSION))
+
+
+class TestFailedBenchNotStamped:
+    """A bench whose migration raised must keep its old version."""
+
+    def test_bench_with_exception_is_not_stamped(self, ctx, benches_dir):
+        make_bench(benches_dir, "test.local")
+
+        stamp = run_migrate(
+            ctx,
+            benches_dir,
+            {"test.local": bench_entry(exception=Exception("boom"), traceback="traceback")},
+            benchname="test.local",
+        )
+
+        stamp.assert_not_called()
+
+    def test_failure_does_not_block_stamping_of_healthy_benches(self, ctx, benches_dir):
+        broken_path = make_bench(benches_dir, "broken.local")
+        healthy_path = make_bench(benches_dir, "healthy.local")
+
+        stamp = run_migrate(
+            ctx,
+            benches_dir,
+            {
+                "broken.local": bench_entry(exception=Exception("boom"), traceback="traceback"),
+                "healthy.local": bench_entry(last_migration_version="0.19.1"),
+            },
+            all_benches=True,
+        )
+
+        stamped_paths = [call.args[0] for call in stamp.call_args_list]
+        assert stamped_paths == [healthy_path]
+        assert broken_path not in stamped_paths
+        assert stamp.call_args_list[0].args[1] == Version(RUNNING_FM_VERSION)
+
+
+class TestExcludedBenchNotStamped:
+    """--exclude-bench keeps a bench out of target_benches entirely."""
+
+    def test_excluded_bench_is_never_stamped(self, ctx, benches_dir):
+        included_path = make_bench(benches_dir, "included.local")
+        excluded_path = make_bench(benches_dir, "excluded.local")
+
+        stamp = run_migrate(
+            ctx,
+            benches_dir,
+            {"included.local": bench_entry(last_migration_version="0.19.1")},
+            all_benches=True,
+            exclude_bench="excluded.local",
+        )
+
+        stamped_paths = [call.args[0] for call in stamp.call_args_list]
+        assert stamped_paths == [included_path]
+        assert excluded_path not in stamped_paths
+        assert stamp.call_args_list[0].args[1] == Version(RUNNING_FM_VERSION)

--- a/tests/unit/migration_manager/test_migrate_0_19_1.py
+++ b/tests/unit/migration_manager/test_migrate_0_19_1.py
@@ -1,0 +1,264 @@
+"""
+Tests for the v0.19.1 migration (image re-tagging).
+
+v0.19.1 has no structural changes: it only re-tags the fm images in each
+bench's generated compose files and stamps ``x-version``. These tests drive
+``MigrationV0191`` against real compose files on disk and only mock Docker.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from ruamel.yaml import YAML
+
+from frappe_manager.migration_manager.migration_exections import MigrationExceptionInBench
+from frappe_manager.migration_manager.migration_helpers import MigrationBench
+from frappe_manager.migration_manager.migrations.migrate_0_19_1 import MigrationV0191
+
+FRAPPE_IMAGE = "ghcr.io/rtcamp/frappe-manager-frappe"
+NGINX_IMAGE = "ghcr.io/rtcamp/frappe-manager-nginx"
+REDIS_IMAGE = "redis:8-alpine"
+
+COMPOSE_MAIN_V0190 = f"""x-version: 0.19.0
+services:
+  frappe:
+    image: {FRAPPE_IMAGE}:v0.19.0
+    restart: always
+  nginx:
+    image: {NGINX_IMAGE}:v0.19.0
+    restart: always
+  socketio:
+    image: {FRAPPE_IMAGE}:v0.19.0
+    restart: always
+  schedule:
+    image: {FRAPPE_IMAGE}:v0.19.0
+    restart: always
+  redis-cache:
+    image: {REDIS_IMAGE}
+    restart: always
+"""
+
+COMPOSE_WORKERS_V0190 = f"""x-version: 0.19.0
+services:
+  bench-default-worker:
+    image: {FRAPPE_IMAGE}:v0.19.0
+    restart: always
+  bench-long-worker:
+    image: {FRAPPE_IMAGE}:v0.19.0
+    restart: always
+"""
+
+COMPOSE_ADMIN_TOOLS = """services:
+  adminer:
+    image: adminer:4
+    restart: always
+  mailpit:
+    image: axllent/mailpit:v1.22
+    restart: always
+"""
+
+COMPOSE_OVERRIDE = """services:
+  frappe:
+    environment:
+      MY_OWN_KNOB: "1"
+"""
+
+
+def load_yaml(path):
+    return YAML(typ="safe").load(path.read_text())
+
+
+def service_images(path) -> dict[str, str]:
+    return {name: config["image"] for name, config in load_yaml(path)["services"].items() if "image" in config}
+
+
+@pytest.fixture
+def make_bench(tmp_path):
+    """Build a MigrationBench over real compose files, with only Docker mocked."""
+
+    def _make(name="test-bench", workers=True, admin_tools=True, override=False):
+        bench_path = tmp_path / "sites" / name
+        bench_path.mkdir(parents=True, exist_ok=True)
+
+        (bench_path / "docker-compose.yml").write_text(COMPOSE_MAIN_V0190)
+        if workers:
+            (bench_path / "docker-compose.workers.yml").write_text(COMPOSE_WORKERS_V0190)
+        if admin_tools:
+            (bench_path / "docker-compose.admin-tools.yml").write_text(COMPOSE_ADMIN_TOOLS)
+        if override:
+            (bench_path / "docker-compose.override.yml").write_text(COMPOSE_OVERRIDE)
+
+        def make_compose_file_manager(compose_path, *args, **kwargs):
+            manager = MagicMock()
+            manager.compose_path = compose_path
+            manager.get_services_list.return_value = ["frappe"]
+            manager.get_container_names.return_value = {}
+            return manager
+
+        with (
+            patch(
+                "frappe_manager.migration_manager.migration_helpers.DockerClient",
+                side_effect=lambda *args, **kwargs: MagicMock(),
+            ),
+            patch(
+                "frappe_manager.migration_manager.migration_helpers.ComposeFile",
+                side_effect=make_compose_file_manager,
+            ),
+        ):
+            bench = MigrationBench(name=name, path=bench_path)
+
+        # Nothing is up: keeps `running`/`workers_running` deterministic so the
+        # migration never tries to recreate containers.
+        bench.docker.compose.get_all_services_status.return_value = []
+        bench.workers_docker.compose.get_all_services_status.return_value = []
+        bench.docker.compose.pull.return_value = Mock(exit_code=0)
+
+        return bench
+
+    return _make
+
+
+@pytest.fixture
+def make_migration():
+    """Build MigrationV0191 with the fm version / installed image tag pinned."""
+
+    def _make(fm_version="0.19.1", image_tag="v0.19.1"):
+        with (
+            patch("frappe_manager.utils.helpers.get_current_fm_version", return_value=fm_version),
+            patch("frappe_manager.utils.helpers.get_docker_image_tag", return_value=image_tag),
+        ):
+            migration = MigrationV0191()
+
+        migration.migration_executor = Mock()
+        return migration
+
+    return _make
+
+
+class TestMigrationV0191ComposeRetag:
+    """Compose files are re-tagged and stamped; foreign images are left alone."""
+
+    def test_retags_fm_images_and_stamps_version_in_main_and_workers(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+
+        migration.migrate_bench(bench)
+
+        main = bench.path / "docker-compose.yml"
+        assert service_images(main) == {
+            "frappe": f"{FRAPPE_IMAGE}:v0.19.1",
+            "nginx": f"{NGINX_IMAGE}:v0.19.1",
+            "socketio": f"{FRAPPE_IMAGE}:v0.19.1",
+            "schedule": f"{FRAPPE_IMAGE}:v0.19.1",
+            "redis-cache": REDIS_IMAGE,
+        }, "every fm image should move to v0.19.1 and redis must be untouched"
+        assert str(load_yaml(main)["x-version"]) == "0.19.1"
+
+        workers = bench.path / "docker-compose.workers.yml"
+        assert service_images(workers) == {
+            "bench-default-worker": f"{FRAPPE_IMAGE}:v0.19.1",
+            "bench-long-worker": f"{FRAPPE_IMAGE}:v0.19.1",
+        }
+        assert str(load_yaml(workers)["x-version"]) == "0.19.1"
+
+    def test_compose_without_fm_images_is_untouched(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        admin_tools = bench.path / "docker-compose.admin-tools.yml"
+        before = admin_tools.read_bytes()
+
+        migration.migrate_bench(bench)
+
+        after = admin_tools.read_bytes()
+        assert after == before, "admin-tools has no fm images, so it must not be rewritten"
+        assert "x-version" not in after.decode(), "no x-version key may be introduced"
+
+    def test_pulls_once_and_second_run_is_a_no_op(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+
+        migration.migrate_bench(bench)
+        assert bench.compose.pull.call_count == 1, "first run changes images, so it must pull"
+
+        after_first_run = (bench.path / "docker-compose.yml").read_bytes()
+        bench.compose.pull.reset_mock()
+
+        migration.migrate_bench(bench)
+
+        assert bench.compose.pull.call_count == 0, "nothing changed, so the second run must not pull"
+        assert (bench.path / "docker-compose.yml").read_bytes() == after_first_run
+
+
+class TestMigrationV0191ImageTagSelection:
+    """Regression guard for issue #452: stable releases tag with their own version."""
+
+    @pytest.mark.parametrize(
+        ("fm_version", "installed_tag"),
+        [
+            ("0.19.1", "v0.19.0"),  # stale installed tag must not win
+            ("0.20.5", "v0.20.5"),  # a newer running fm must not win either
+        ],
+    )
+    def test_stable_release_tags_with_migration_version(self, make_migration, make_bench, fm_version, installed_tag):
+        migration = make_migration(fm_version=fm_version, image_tag=installed_tag)
+        bench = make_bench()
+
+        assert migration.is_dev_environment is False
+        assert migration._get_image_tag_for_migration() == "v0.19.1"
+
+        migration.migrate_bench(bench)
+
+        images = service_images(bench.path / "docker-compose.yml")
+        assert images["frappe"] == f"{FRAPPE_IMAGE}:v0.19.1"
+        assert images["nginx"] == f"{NGINX_IMAGE}:v0.19.1"
+
+    def test_dev_release_tags_with_installed_image_tag(self, make_migration, make_bench):
+        migration = make_migration(fm_version="0.20.0.dev0", image_tag="v0.20.0.dev0")
+        bench = make_bench()
+
+        assert migration.is_dev_environment is True
+        assert migration._get_image_tag_for_migration() == "v0.20.0.dev0"
+
+        migration.migrate_bench(bench)
+
+        main = bench.path / "docker-compose.yml"
+        images = service_images(main)
+        assert images["frappe"] == f"{FRAPPE_IMAGE}:v0.20.0.dev0"
+        assert images["nginx"] == f"{NGINX_IMAGE}:v0.20.0.dev0"
+        assert images["redis-cache"] == REDIS_IMAGE
+        assert str(load_yaml(main)["x-version"]) == "0.19.1", "x-version tracks the migration, not the image tag"
+
+
+class TestMigrationV0191PullFailure:
+    def test_non_zero_pull_exit_code_raises(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        bench.compose.pull.return_value = Mock(exit_code=1)
+
+        with pytest.raises(MigrationExceptionInBench, match="test-bench"):
+            migration._pull_bench_images(bench)
+
+    def test_zero_pull_exit_code_does_not_raise(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        bench.compose.pull.return_value = Mock(exit_code=0)
+
+        migration._pull_bench_images(bench)
+
+        bench.compose.pull.assert_called_once_with(stream=False)
+
+
+class TestManagedComposePaths:
+    def test_returns_generated_files_in_declared_order_and_ignores_override(self, make_bench):
+        bench = make_bench(override=True)
+
+        assert bench.managed_compose_paths == [
+            bench.path / "docker-compose.yml",
+            bench.path / "docker-compose.workers.yml",
+            bench.path / "docker-compose.admin-tools.yml",
+        ]
+
+    def test_skips_generated_files_that_are_absent(self, make_bench):
+        bench = make_bench(workers=False, admin_tools=False, override=True)
+
+        assert bench.managed_compose_paths == [bench.path / "docker-compose.yml"]

--- a/tests/unit/migration_manager/test_migrate_0_19_1.py
+++ b/tests/unit/migration_manager/test_migrate_0_19_1.py
@@ -88,7 +88,7 @@ def make_bench(tmp_path):
         if override:
             (bench_path / "docker-compose.override.yml").write_text(COMPOSE_OVERRIDE)
 
-        def make_compose_file_manager(compose_path, *args, **kwargs):
+        def make_compose_file_manager(compose_path, *_args, **_kwargs):
             manager = MagicMock()
             manager.compose_path = compose_path
             manager.get_services_list.return_value = ["frappe"]
@@ -98,7 +98,7 @@ def make_bench(tmp_path):
         with (
             patch(
                 "frappe_manager.migration_manager.migration_helpers.DockerClient",
-                side_effect=lambda *args, **kwargs: MagicMock(),
+                side_effect=lambda *_args, **_kwargs: MagicMock(),
             ),
             patch(
                 "frappe_manager.migration_manager.migration_helpers.ComposeFile",

--- a/tests/unit/migration_manager/test_migrate_0_19_1.py
+++ b/tests/unit/migration_manager/test_migrate_0_19_1.py
@@ -248,6 +248,71 @@ class TestMigrationV0191PullFailure:
         bench.compose.pull.assert_called_once_with(stream=False)
 
 
+class TestMigrationV0191Recreate:
+    """Containers already up must end on the new image without a manual restart."""
+
+    @staticmethod
+    def _mark_running(bench, *, nginx="running"):
+        """Report every main-compose service as up, nginx overridable."""
+        bench.compose_file_manager.get_services_list.return_value = ["frappe", "nginx"]
+        bench.compose_file_manager.get_container_names.return_value = {
+            "frappe": "fm__test__frappe",
+            "nginx": "fm__test__nginx",
+        }
+        bench.docker.compose.get_all_services_status.return_value = [
+            {"Name": "fm__test__frappe", "Service": "frappe", "State": "running"},
+            {"Name": "fm__test__nginx", "Service": "nginx", "State": nginx},
+        ]
+
+    def test_running_bench_is_recreated_after_the_pull(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        self._mark_running(bench)
+
+        migration.migrate_bench(bench)
+
+        bench.compose.up.assert_any_call(detach=True, pull="never")
+
+    def test_stopped_bench_is_left_stopped(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+
+        migration.migrate_bench(bench)
+
+        bench.compose.up.assert_not_called()
+        bench.workers_docker.compose.up.assert_not_called()
+
+    def test_no_recreate_when_images_did_not_move(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        self._mark_running(bench)
+
+        migration.migrate_bench(bench)
+        bench.compose.up.reset_mock()
+
+        migration.migrate_bench(bench)
+
+        bench.compose.up.assert_not_called()
+
+    def test_nginx_killed_by_the_recreate_race_is_brought_back(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        self._mark_running(bench, nginx="exited")
+
+        migration._ensure_nginx_running(bench)
+
+        bench.compose.up.assert_called_once_with(services=["nginx"], detach=True, pull="never")
+
+    def test_surviving_nginx_is_left_alone(self, make_migration, make_bench):
+        migration = make_migration()
+        bench = make_bench()
+        self._mark_running(bench)
+
+        migration._ensure_nginx_running(bench)
+
+        bench.compose.up.assert_not_called()
+
+
 class TestManagedComposePaths:
     def test_returns_generated_files_in_declared_order_and_ignores_override(self, make_bench):
         bench = make_bench(override=True)


### PR DESCRIPTION
Fixes: #452 

This pull request introduces several improvements and fixes across the release automation, Docker image builds, migration robustness, and workflow reliability. The most significant changes are grouped and summarized below.

**Release Automation and Workflow Reliability:**

* Enforces that the package version in `frappe_manager/__about__.py` matches the release tag in all release-related workflows, preventing accidental mismatches between code and published artifacts. (`.github/workflows/draft-release.yml`, `.github/workflows/release-prepare.yml`, `.github/workflows/tag-on-release-merge.yml`) [[1]](diffhunk://#diff-3d80a0bd2aa867253847d98ff0fddb8982d61587bee3ddfb9906f4aafbe55329L61-R72) [[2]](diffhunk://#diff-c653f3e33b01c829488a4008bada88d6987346456be9abb31ce6064ea518410aR51-R71) [[3]](diffhunk://#diff-91f48dafca2e12af5c541f9966b42b761431374a040458dc22a986aeddce503bR19-R49)
* Refactors the release preparation workflow to always base `docs/changelog.md` on the latest `main` branch, avoiding merge conflicts and ensuring the changelog is up to date. (`.github/workflows/release-prepare.yml`)
* Updates the tag-on-release-merge workflow to use a personal access token if available, ensuring that pushing a tag triggers downstream workflows (`draft-release.yml`, `bake-images.yml`), and adds clear warnings if not. (`.github/workflows/tag-on-release-merge.yml`)
* Simplifies and clarifies the release PR checklist, ensuring maintainers verify changelog accuracy and avoid duplicate entries. (`.github/workflows/release-prepare.yml`)

**Docker Image Build Improvements:**

* Refactors the build matrix in `bake-images.yml` to use a single `target` object for platform/arch/os, improving clarity and maintainability. Also, implements a more robust build cache scoping mechanism to optimize build performance and avoid cache pollution across branches. (`.github/workflows/bake-images.yml`) [[1]](diffhunk://#diff-b4a36e5d30ff61562173192de6daac88920ff650113d52142d7d7cd5a7b0f9ddR24-R32) [[2]](diffhunk://#diff-b4a36e5d30ff61562173192de6daac88920ff650113d52142d7d7cd5a7b0f9ddL89-R148)
* Adds required Chromium runtime libraries to the Frappe Docker image to support PDF generation, improving compatibility on Ubuntu Jammy. (`Docker/frappe/Dockerfile`)

**Migration Robustness:**

* Ensures all migration-managed compose files (including worker and admin tools compose files) are backed up before migrations, improving rollback reliability. (`frappe_manager/migration_manager/migration_base.py`, `frappe_manager/migration_manager/migration_helpers.py`) [[1]](diffhunk://#diff-d5ebe48228f8184dfb6ba3c93e837f5daf683f3fb744769ee107699192fb1588L207-R210) [[2]](diffhunk://#diff-47e6bbad293632ace0c46518a9e38cb006a0e8f9565ef9d80873c7434bd868ebR31-R44)
* Fixes logic in migration result handling to correctly mark benches as migrated or failed, and ensures benches not requiring migration are updated to the current version. (`frappe_manager/commands/migrate.py`)

**Other:**

* Removes unnecessary permissions from the tag-on-release-merge workflow for improved security. (`.github/workflows/tag-on-release-merge.yml`)